### PR TITLE
Make cbhwlib Qt5 compatible

### DIFF
--- a/cbhwlib/CCFUtilsConcurrent.cpp
+++ b/cbhwlib/CCFUtilsConcurrent.cpp
@@ -37,7 +37,7 @@ using namespace ccf;
 void ReadCCFHelper(QString strFileName, bool bSend, cbCCF * pCCF, cbCCFCallback pCallbackFn, UINT32 nInstance)
 {
     // make sure byte array is constructed, thus we can use the internal pointer to character data
-    const QByteArray tmp = strFileName.toAscii();
+    const QByteArray tmp = strFileName.toLatin1();
     LPCSTR szFileName = tmp;
     if (pCallbackFn)
         pCallbackFn(nInstance, CCFRESULT_SUCCESS, szFileName, CCFSTATE_THREADREAD, 0);
@@ -66,7 +66,7 @@ void ccf::ConReadCCF(LPCSTR szFileName, bool bSend, cbCCF * pCCF, cbCCFCallback 
 void WriteCCFHelper(QString strFileName, cbCCF ccf, cbCCFCallback pCallbackFn, UINT32 nInstance)
 {
     // make sure byte array is constructed, thus we can use the internal pointer to character data
-    const QByteArray tmp = strFileName.toAscii();
+    const QByteArray tmp = strFileName.toLatin1();
     LPCSTR szFileName = tmp;
     QThread::currentThread()->setPriority(QThread::LowestPriority);
     if (pCallbackFn)

--- a/cbhwlib/CCFUtilsXmlItems.cpp
+++ b/cbhwlib/CCFUtilsXmlItems.cpp
@@ -1180,7 +1180,7 @@ template<>
 void ccf::ReadItem(XmlFile * const xml, char item[], int count)
 {
     QString var = xml->value().toString();
-    strncpy(item, var.toAscii().constData(), count);
+    strncpy(item, var.toLatin1().constData(), count);
     item[count - 1] = 0;
 }
 

--- a/cbhwlib/InstNetwork.cpp
+++ b/cbhwlib/InstNetwork.cpp
@@ -712,8 +712,8 @@ void InstNetwork::run()
         bool bHighLatency = (m_instInfo & (cbINSTINFO_NPLAY | cbINSTINFO_CEREPLEX));
         m_icInstrument.Reset(bHighLatency ? (int)INST_TICK_COUNT : (int)Instrument::TICK_COUNT);
         // Set network connection details
-        const QByteArray inIP = m_strInIP.toAscii();
-        const QByteArray outIP = m_strOutIP.toAscii();
+        const QByteArray inIP = m_strInIP.toLatin1();
+        const QByteArray outIP = m_strOutIP.toLatin1();
         m_icInstrument.SetNetwork(m_nInPort, m_nOutPort, inIP, outIP);
         // Open UDP
         cbRESULT cbres = m_icInstrument.Open(startupOption, m_bBroadcast, m_bDontRoute, m_bNonBlocking, m_nRecBufSize);

--- a/cbhwlib/XmlFile.cpp
+++ b/cbhwlib/XmlFile.cpp
@@ -369,9 +369,9 @@ bool XmlFile::endGroup(bool bSave /* = true */)
         }
 #ifdef DEBUG_XMLFILE
         if (bSave)
-            TRACE("save doc: %s\n", m_doc.toString().toAscii().constData());
+            TRACE("save doc: %s\n", m_doc.toString().toLatin1().constData());
         else
-            TRACE("load doc: %s\n", m_doc.toString().toAscii().constData());
+            TRACE("load doc: %s\n", m_doc.toString().toLatin1().constData());
 #endif
     }
 


### PR DESCRIPTION
All that needs to be done to support Qt5 (while maintaining Qt4 compatibility) is to replace all calls to QString.toAscii() with QString.toLatin1(). 

Both function do the same, so there is no change in functionality.