### PR TITLE
Add protocol version check on cbOpen

### DIFF
--- a/cbhwlib/InstNetwork.cpp
+++ b/cbhwlib/InstNetwork.cpp
@@ -675,16 +675,16 @@ void InstNetwork::run()
     }
 
     m_nIdx = cb_library_index[m_nInstance];
-
-    if (cbOpen(FALSE, m_nInstance) == cbRESULT_OK)
+    
+    // Open the cbhwlib library and create the shared objects
+    cbRESULT cbRet = cbOpen(FALSE, m_nInstance);
+    if (cbRet == cbRESULT_OK)
     {
         m_nIdx = cb_library_index[m_nInstance];
         m_bStandAlone = false;
         InstNetworkEvent(NET_EVENT_NETCLIENT); // Client to the Central application
-    } else { // If Central is not running run as stand alone
+    } else if (cbRet == cbRESULT_NOCENTRALAPP) { // If Central is not running run as stand alone
         m_bStandAlone = true; // Run stand alone without Central
-        // Open the cbhwlib library and create the shared objects
-        cbRESULT cbRet;
         // Run as stand-alone application
         cbRet = cbOpen(TRUE, m_nInstance);
         if (cbRet)
@@ -694,6 +694,10 @@ void InstNetwork::run()
         }
         m_nIdx = cb_library_index[m_nInstance];
         InstNetworkEvent(NET_EVENT_NETSTANDALONE); // Stand-alone application
+    } else {
+        // Report error and quit
+        InstNetworkEvent(NET_EVENT_CBERR, cbRet);
+        return;
     }
 
     STARTUP_OPTIONS startupOption = m_nStartupOptionsFlags;

--- a/cbhwlib/cbhwlib.cpp
+++ b/cbhwlib/cbhwlib.cpp
@@ -359,6 +359,18 @@ cbRESULT cbOpen(BOOL bStandAlone, UINT32 nInstance)
     cb_cfg_buffer_ptr[nIdx] = (cbCFGBUFF*)GetSharedBuffer(cb_cfg_buffer_hnd[nIdx], true);
     if (cb_cfg_buffer_ptr[nIdx] == NULL) {  cbClose(false, nInstance);  return cbRESULT_LIBINITERROR; }
 
+    // Check version of hardware protocol if available
+    if (cb_cfg_buffer_ptr[nIdx]->procinfo[0].chid != 0) {
+        if (cb_cfg_buffer_ptr[nIdx]->procinfo[0].version > cbVersion()) {
+            cbClose(false, nInstance);
+            return cbRESULT_LIBOUTDATED;
+        }
+        if (cb_cfg_buffer_ptr[nIdx]->procinfo[0].version < cbVersion()) {
+            cbClose(false, nInstance);
+            return cbRESULT_INSTOUTDATED;
+        }
+    }
+
     if (nInstance == 0)
         _snprintf(buf, sizeof(buf), "%s", STATUS_BUF_NAME);
     else

--- a/cbhwlib/cbhwlib.h
+++ b/cbhwlib/cbhwlib.h
@@ -352,6 +352,8 @@ typedef unsigned int cbRESULT;
 #define cbRESULT_INSTINVALID       24   // Invalid range or instrument address
 #define cbRESULT_SOCKBIND          25   // Cannot bind to any address (possibly no Instrument network)
 #define cbRESULT_SYSLOCK           26   // Cannot (un)lock the system resources (possiblly resource busy)
+#define cbRESULT_INSTOUTDATED      27   // The instrument runs an outdated protocol version
+#define cbRESULT_LIBOUTDATED       28   // The library is outdated
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -382,7 +384,7 @@ UINT32 cbVersion(void);
 cbRESULT cbOpen(BOOL bStandAlone = FALSE, UINT32 nInstance = 0);
 // Initializes the Neuromatic library (and establishes a link to the Central Control Application if bStandAlone is FALSE).
 // This function must be called before any other functions are called from this library.
-// Returns OK, NOCENTRALAPP, LIBINITERROR, MEMORYUNVAIL, or HARDWAREOFFLINE
+// Returns OK, NOCENTRALAPP, LIBINITERROR, MEMORYUNVAIL, HARDWAREOFFLINE, INSTOUTDATED or LIBOUTDATED
 
 cbRESULT cbClose(BOOL bStandAlone = FALSE, UINT32 nInstance = 0);
 // Close the library (must match how library is openned)

--- a/cbmex/cbsdk.cpp
+++ b/cbmex/cbsdk.cpp
@@ -773,6 +773,12 @@ cbSdkResult SdkApp::SdkOpen(UINT32 nInstance, cbSdkConnectionType conType, cbSdk
             case cbRESULT_BUFSPKALLOCERR:
                 sdkres = CBSDKRESULT_ERRMEMORY;
                 break;
+            case cbRESULT_INSTOUTDATED:
+                sdkres = CBSDKRESULT_INSTOUTDATED;
+                break;
+            case cbRESULT_LIBOUTDATED:
+                sdkres = CBSDKRESULT_LIBOUTDATED;
+                break;
             case cbRESULT_OK:
                 sdkres = CBSDKRESULT_ERROFFLINE;
                 break;

--- a/cbmex/cbsdk.h
+++ b/cbmex/cbsdk.h
@@ -113,6 +113,8 @@ typedef enum _cbSdkResult
     CBSDKRESULT_TIMEOUT                =   -28, // Conection timeout error
     CBSDKRESULT_BUSY                   =   -29, // Resource is busy
     CBSDKRESULT_ERROFFLINE             =   -30, // Instrument is offline
+    CBSDKRESULT_INSTOUTDATED           =   -31, // The instrument runs an outdated protocol version
+    CBSDKRESULT_LIBOUTDATED            =   -32, // The library is outdated
 } cbSdkResult;
 
 typedef enum _cbSdkConnectionType


### PR DESCRIPTION
This patch make hwlib (and cbsdk) throw an 'outdated' error if instrument and the library used different versions of the hwlib/protocol.

Tested on Windows with different values of cbVERSION_MAJOR and cbVERSION_MINOR.