### PR TITLE
Fixed a few minor warnings in XCode.

### DIFF
--- a/cbhwlib/CCFUtils.cpp
+++ b/cbhwlib/CCFUtils.cpp
@@ -32,9 +32,16 @@ using namespace ccf;
 // Purpose: CCF base constructor
 CCFUtils::CCFUtils(bool bSend, bool bThreaded, cbCCF * pCCF, cbCCFCallback pCallbackFn, UINT32 nInstance) :
     m_pImpl(NULL),
-    m_nInternalVersion(0), m_nInternalOriginalVersion(0),
-    m_szFileName(NULL), m_bAutoSort(FALSE), m_bBinaryOriginal(FALSE),
-    m_bSend(bSend), m_bThreaded(bThreaded), m_pCCF(pCCF), m_pCallbackFn(pCallbackFn), m_nInstance(nInstance)
+    m_bSend(bSend),
+    m_pCallbackFn(pCallbackFn),
+    m_bThreaded(bThreaded),
+    m_pCCF(pCCF),
+    m_nInternalVersion(0),
+    m_nInternalOriginalVersion(0),
+    m_nInstance(nInstance),
+    m_szFileName(NULL),
+    m_bAutoSort(FALSE),
+    m_bBinaryOriginal(FALSE)
 {
     // Initial copy
     if (pCCF)

--- a/cbhwlib/InstNetwork.cpp
+++ b/cbhwlib/InstNetwork.cpp
@@ -29,14 +29,28 @@
 // Author & Date: Ehsan Azar       15 March 2010
 // Purpose: Constructor for instrument networking thread
 InstNetwork::InstNetwork(STARTUP_OPTIONS startupOption) :
-    QThread(), m_nStartupOptionsFlags(startupOption), m_enLOC(LOC_LOW), m_bStandAlone(true),
-            m_timerTicks(0), m_timerId(0), m_bDone(false),
-            m_nRecentPacketCount(0), m_dataCounter(0), m_nLastNumberOfPacketsReceived(0),
-            m_runlevel(cbRUNLEVEL_SHUTDOWN), m_nIdx(0), m_instInfo(0),
-            m_nInstance(0), m_nInPort(NSP_IN_PORT), m_nOutPort(NSP_OUT_PORT),
-            m_bBroadcast(false), m_bDontRoute(true), m_bNonBlocking(true),
-            m_nRecBufSize(NSP_REC_BUF_SIZE),
-            m_strInIP(NSP_IN_ADDRESS), m_strOutIP(NSP_OUT_ADDRESS)
+    QThread(),
+    m_enLOC(LOC_LOW),
+    m_nStartupOptionsFlags(startupOption),
+    m_timerTicks(0),
+    m_timerId(0),
+    m_bDone(false),
+    m_nRecentPacketCount(0),
+    m_dataCounter(0),
+    m_nLastNumberOfPacketsReceived(0),
+    m_runlevel(cbRUNLEVEL_SHUTDOWN),
+    m_bStandAlone(true),
+    m_instInfo(0),
+    m_nInstance(0),
+    m_nIdx(0),
+    m_nInPort(NSP_IN_PORT),
+    m_nOutPort(NSP_OUT_PORT),
+    m_bBroadcast(false),
+    m_bDontRoute(true),
+    m_bNonBlocking(true),
+    m_nRecBufSize(NSP_REC_BUF_SIZE),
+    m_strInIP(NSP_IN_ADDRESS),
+    m_strOutIP(NSP_OUT_ADDRESS)
 {
 
     qRegisterMetaType<NetEventType>("NetEventType"); // For QT connect to recognize this type

--- a/cbhwlib/cbhwlib.h
+++ b/cbhwlib/cbhwlib.h
@@ -3042,8 +3042,8 @@ private:
 
 public:
     cbPcStatus() :
-        m_iBlockRecording(0),
-        isSelection(1)
+        isSelection(1),
+        m_iBlockRecording(0)
         {
         }
     bool IsRecordingBlocked() { return m_iBlockRecording != 0; }

--- a/n2h5/main.cpp
+++ b/n2h5/main.cpp
@@ -165,7 +165,7 @@ int AddRoot(const char * szSrcFile, FILE * pFile, hid_t file, Nsx21Hdr & isHdr)
         printf("Cannot get file attributes\n");
         return 1;
     }
-    time_t t = st.st_mtime;
+//unused    time_t t = st.st_mtime;
     // TODO: use strftime to convert to st
 #endif
 
@@ -537,7 +537,7 @@ int ConvertNev(FILE * pFile, hid_t file)
         hid_t tid_synch_attr = CreateSynchAttrType(gid_video);
         tid_synch = CreateSynchType(gid_video);
         // Add synchronization groups
-        if (synchAttr.szLabel != NULL)
+        if (synchAttr.szLabel != NULL)  // Warning: Always true!
         {
             bHasVideo = true;
             char szNum[7];
@@ -561,7 +561,7 @@ int ConvertNev(FILE * pFile, hid_t file)
         for (int i = 0; i < cbMAXTRACKOBJ; ++i)
         {
             tid_tracking[i] = -1;
-            if (trackingAttr[i].szLabel != NULL)
+            if (trackingAttr[i].szLabel != NULL)  // Warning: Always true!
             {
                 bHasVideo = true;
                 int dim = 2, width = 2;
@@ -1089,7 +1089,7 @@ int ConvertNSx22(FILE * pFile, hid_t file)
     // Read the header
     fseeko(pFile, 0, SEEK_SET);    // read header from beginning of file
     fread(&isHdr, sizeof(isHdr), 1, pFile);
-    UINT64 dataStart = isHdr.nBytesInHdrs + sizeof(Nsx22DataHdr);
+    //UINT64 dataStart = isHdr.nBytesInHdrs + sizeof(Nsx22DataHdr);
 
     if (isHdr.cnChannels > cbNUM_ANALOG_CHANS)
     {

--- a/n2h5/n2h5.cpp
+++ b/n2h5/n2h5.cpp
@@ -409,7 +409,6 @@ hid_t CreateTrackingType(hid_t loc, int dim, int width)
 
     switch (width)
     {
-    hid_t tid;
     case 1:
         strLabel += "8";
         tid_coords = H5Tcopy(H5T_NATIVE_UINT8);


### PR DESCRIPTION
Mostly incorrect order of member variable initializations and a few unused variables. I was unable to remove a couple warnings (comparison always evaluate to true) because I'm not sure what the intended behaviour is.