### PR TITLE
On Mac, default con.szInIP should be 255.255.255.255

### DIFF
--- a/cbmex/cbsdk.cpp
+++ b/cbmex/cbsdk.cpp
@@ -753,6 +753,8 @@ cbSdkResult SdkApp::SdkOpen(UINT32 nInstance, cbSdkConnectionType conType, cbSdk
     {
 #ifdef WIN32
         con.szInIP = cbNET_UDP_ADDR_INST;
+#elif __APPLE__
+        con.szInIP = "255.255.255.255";
 #else
         // On Linux bind to bcast
         con.szInIP = cbNET_UDP_ADDR_BCAST;


### PR DESCRIPTION
As per [kb article](http://support.blackrockmicro.com/KB/View/168747-using-cbmex-on-osx), the szInIp field should be 255.255.255.255 on MacOS. With this change, ./testcbsdk now works.

An alternative to the change here is to wrap the [cbNET_UDP_ADDR_BCAST #define in cbhwlib.h](https://github.com/dashesy/CereLink/blob/master/cbhwlib/cbhwlib.h#L202) in an `#ifdef __APPLE__` `#else` `#endif`. I guessed that putting the conditional in the .cpp was preferred because that's where it already was for WIN32.