### PR TITLE
Parse packets based on channel caps instead of channel number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 dist/
 build*/
+cerebus.egg-info
+*.pyd
 
 .*
 *.*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 dist/
 build*/
-cerebus.egg-info
+*.egg-info
 *.pyd
 
 .*
@@ -34,4 +34,3 @@ Release/
 cerebus/cbpy.so
 cerebus/cbpy.cpp
 cerebus/cbpyw.cpp
-cerelink.egg-info

--- a/cbhwlib/InstNetwork.cpp
+++ b/cbhwlib/InstNetwork.cpp
@@ -151,9 +151,9 @@ void InstNetwork::ProcessIncomingPacket(const cbPKT_GENERIC * const pPkt)
                     if (chan > 0 && chan <= cbMAXCHANS)
                     {
                         memcpy(&(cb_cfg_buffer_ptr[m_nIdx]->chaninfo[chan - 1]), pPkt, sizeof(cbPKT_CHANINFO));
-						// Invalidate the cache
+                        // Invalidate the cache
                         if ((pPkt->type == cbPKTTYPE_CHANREP) && (m_ChannelType[chan - 1] == cbCHANTYPE_ANAIN))
-							cb_spk_buffer_ptr[m_nIdx]->cache[chan - 1].valid = 0;
+                            cb_spk_buffer_ptr[m_nIdx]->cache[chan - 1].valid = 0;
                     }
                 }
             }
@@ -354,12 +354,12 @@ void InstNetwork::ProcessIncomingPacket(const cbPKT_GENERIC * const pPkt)
                 {
                     const cbPKT_AOUT_WAVEFORM * pPktAoutWave = reinterpret_cast<const cbPKT_AOUT_WAVEFORM *>(pPkt);
                     uint16_t nChan = pPktAoutWave->chan;
-					if ((m_ChannelType[nChan-1] == cbCHANTYPE_ANAOUT) || (m_ChannelType[nChan - 1] == cbCHANTYPE_AUDOUT))
-					{
-						uint8_t trigNum = pPktAoutWave->trigNum;
-						if (trigNum < cbMAX_AOUT_TRIGGER)
-							cb_cfg_buffer_ptr[m_nIdx]->isWaveform[nChan][trigNum] = *pPktAoutWave;
-					}
+                    if ((m_ChannelType[nChan-1] == cbCHANTYPE_ANAOUT) || (m_ChannelType[nChan - 1] == cbCHANTYPE_AUDOUT))
+                    {
+                        uint8_t trigNum = pPktAoutWave->trigNum;
+                        if (trigNum < cbMAX_AOUT_TRIGGER)
+                            cb_cfg_buffer_ptr[m_nIdx]->isWaveform[nChan][trigNum] = *pPktAoutWave;
+                    }
                 }
             }
             else if (pPkt->type == cbPKTTYPE_NPLAYREP)
@@ -745,27 +745,27 @@ void InstNetwork::run()
     m_runlevel = cbRUNLEVEL_SHUTDOWN;
     m_bDone = false;
 
-	// Determine the channel type for each channel.
-	for (uint32_t ch_ix = 0; ch_ix < cbMAXCHANS; ch_ix++)
-	{
-		uint32_t chancaps;
-		cbRESULT res = cbGetChanCaps(ch_ix + 1, &chancaps, m_nInstance);
-		if ((chancaps & cbCHAN_AINP) == cbCHAN_AINP)
-			m_ChannelType[ch_ix] = cbCHANTYPE_ANAIN;
-		else if ((chancaps & cbCHAN_AOUT) == cbCHAN_AOUT)
-			m_ChannelType[ch_ix] = cbCHANTYPE_ANAOUT;
-		else if ((chancaps & cbCHAN_DINP) == cbCHAN_DINP)
-		{
-			uint32_t diginCaps;
-			res = cbGetDinpCaps(ch_ix + 1, &diginCaps, m_nInstance);
-			if (diginCaps & cbDINP_SERIALMASK)
-				m_ChannelType[ch_ix] = cbCHANTYPE_SERIAL;
-			else
-				m_ChannelType[ch_ix] = cbCHANTYPE_DIGIN;
-		}
-		else if ((chancaps & cbCHAN_DOUT) == cbCHAN_DOUT)
-			m_ChannelType[ch_ix] = cbCHANTYPE_DIGOUT;
-	}
+    // Determine the channel type for each channel.
+    for (uint32_t ch_ix = 0; ch_ix < cbMAXCHANS; ch_ix++)
+    {
+        uint32_t chancaps;
+        cbRESULT res = cbGetChanCaps(ch_ix + 1, &chancaps, m_nInstance);
+        if ((chancaps & cbCHAN_AINP) == cbCHAN_AINP)
+            m_ChannelType[ch_ix] = cbCHANTYPE_ANAIN;
+        else if ((chancaps & cbCHAN_AOUT) == cbCHAN_AOUT)
+            m_ChannelType[ch_ix] = cbCHANTYPE_ANAOUT;
+        else if ((chancaps & cbCHAN_DINP) == cbCHAN_DINP)
+        {
+            uint32_t diginCaps;
+            res = cbGetDinpCaps(ch_ix + 1, &diginCaps, m_nInstance);
+            if (diginCaps & cbDINP_SERIALMASK)
+                m_ChannelType[ch_ix] = cbCHANTYPE_SERIAL;
+            else
+                m_ChannelType[ch_ix] = cbCHANTYPE_DIGIN;
+        }
+        else if ((chancaps & cbCHAN_DOUT) == cbCHAN_DOUT)
+            m_ChannelType[ch_ix] = cbCHANTYPE_DIGOUT;
+    }
 
     // If stand-alone setup network packet handling timer
     if (m_bStandAlone)

--- a/cbhwlib/InstNetwork.cpp
+++ b/cbhwlib/InstNetwork.cpp
@@ -151,12 +151,9 @@ void InstNetwork::ProcessIncomingPacket(const cbPKT_GENERIC * const pPkt)
                     if (chan > 0 && chan <= cbMAXCHANS)
                     {
                         memcpy(&(cb_cfg_buffer_ptr[m_nIdx]->chaninfo[chan - 1]), pPkt, sizeof(cbPKT_CHANINFO));
-                        if (pPkt->type == cbPKTTYPE_CHANREP)
-                        {
-                            // Invalidate the cache
-                            if (chan <= cbNUM_ANALOG_CHANS)
-                                cb_spk_buffer_ptr[m_nIdx]->cache[chan - 1].valid = 0;
-                        }
+						// Invalidate the cache
+                        if ((pPkt->type == cbPKTTYPE_CHANREP) && (m_ChannelType[chan - 1] == cbCHANTYPE_ANAIN))
+							cb_spk_buffer_ptr[m_nIdx]->cache[chan - 1].valid = 0;
                     }
                 }
             }
@@ -357,16 +354,12 @@ void InstNetwork::ProcessIncomingPacket(const cbPKT_GENERIC * const pPkt)
                 {
                     const cbPKT_AOUT_WAVEFORM * pPktAoutWave = reinterpret_cast<const cbPKT_AOUT_WAVEFORM *>(pPkt);
                     uint16_t nChan = pPktAoutWave->chan;
-                    if (nChan > cbNUM_ANALOG_CHANS)
-                    {
-                        nChan -= (cbNUM_ANALOG_CHANS + 1);
-                        if (nChan < AOUT_NUM_GAIN_CHANS)
-                        {
-                            uint8_t trigNum = pPktAoutWave->trigNum;
-                            if (trigNum < cbMAX_AOUT_TRIGGER)
-                                cb_cfg_buffer_ptr[m_nIdx]->isWaveform[nChan][trigNum] = *pPktAoutWave;
-                        }
-                    }
+					if ((m_ChannelType[nChan-1] == cbCHANTYPE_ANAOUT) || (m_ChannelType[nChan - 1] == cbCHANTYPE_AUDOUT))
+					{
+						uint8_t trigNum = pPktAoutWave->trigNum;
+						if (trigNum < cbMAX_AOUT_TRIGGER)
+							cb_cfg_buffer_ptr[m_nIdx]->isWaveform[nChan][trigNum] = *pPktAoutWave;
+					}
                 }
             }
             else if (pPkt->type == cbPKTTYPE_NPLAYREP)
@@ -751,6 +744,28 @@ void InstNetwork::run()
     m_nLastNumberOfPacketsReceived = 0;
     m_runlevel = cbRUNLEVEL_SHUTDOWN;
     m_bDone = false;
+
+	// Determine the channel type for each channel.
+	for (uint32_t ch_ix = 0; ch_ix < cbMAXCHANS; ch_ix++)
+	{
+		uint32_t chancaps;
+		cbRESULT res = cbGetChanCaps(ch_ix + 1, &chancaps, m_nInstance);
+		if ((chancaps & cbCHAN_AINP) == cbCHAN_AINP)
+			m_ChannelType[ch_ix] = cbCHANTYPE_ANAIN;
+		else if ((chancaps & cbCHAN_AOUT) == cbCHAN_AOUT)
+			m_ChannelType[ch_ix] = cbCHANTYPE_ANAOUT;
+		else if ((chancaps & cbCHAN_DINP) == cbCHAN_DINP)
+		{
+			uint32_t diginCaps;
+			res = cbGetDinpCaps(ch_ix + 1, &diginCaps, m_nInstance);
+			if (diginCaps & cbDINP_SERIALMASK)
+				m_ChannelType[ch_ix] = cbCHANTYPE_SERIAL;
+			else
+				m_ChannelType[ch_ix] = cbCHANTYPE_DIGIN;
+		}
+		else if ((chancaps & cbCHAN_DOUT) == cbCHAN_DOUT)
+			m_ChannelType[ch_ix] = cbCHANTYPE_DIGOUT;
+	}
 
     // If stand-alone setup network packet handling timer
     if (m_bStandAlone)

--- a/cbhwlib/InstNetwork.h
+++ b/cbhwlib/InstNetwork.h
@@ -122,6 +122,8 @@ protected:
     int m_nRecBufSize;
     QString m_strInIP;  // Client IPv4 address
     QString m_strOutIP; // Instrument IPv4 address
+	uint8_t m_ChannelType[cbMAXCHANS]; // Holds an integer for each channel indicating its type. See cbCHTYPE_ in cbhwlib.h
+	// TODO: Maybe we need a m_ChanIdxInType array for indexing waveform arrays.
 
 public Q_SLOTS:
     void Close(); // stop timer and close the message loop

--- a/cbhwlib/InstNetwork.h
+++ b/cbhwlib/InstNetwork.h
@@ -122,8 +122,8 @@ protected:
     int m_nRecBufSize;
     QString m_strInIP;  // Client IPv4 address
     QString m_strOutIP; // Instrument IPv4 address
-	uint8_t m_ChannelType[cbMAXCHANS]; // Holds an integer for each channel indicating its type. See cbCHTYPE_ in cbhwlib.h
-	// TODO: Maybe we need a m_ChanIdxInType array for indexing waveform arrays.
+    uint8_t m_ChannelType[cbMAXCHANS]; // Holds an integer for each channel indicating its type. See cbCHTYPE_ in cbhwlib.h
+    // TODO: Maybe we need a m_ChanIdxInType array for indexing waveform arrays.
 
 public Q_SLOTS:
     void Close(); // stop timer and close the message loop

--- a/cbhwlib/cbHwlibHi.cpp
+++ b/cbhwlib/cbHwlibHi.cpp
@@ -84,46 +84,46 @@ bool IsRawProcessingEnabled(uint32_t nChan, uint32_t nInstance)
 // TRUE means yes; FALSE, no
 bool IsChanAnyDigIn(uint32_t dwChan, uint32_t nInstance)
 {
-	uint32_t dwChanCaps;
-	bool result;
+    uint32_t dwChanCaps;
+    bool result;
 
-	result = dwChan >= MIN_CHANS;
-	result &= cbGetChanCaps(dwChan, &dwChanCaps, nInstance) == cbRESULT_OK;
-	result &= (dwChanCaps & cbCHAN_DINP) == cbCHAN_DINP;
-	return result;
+    result = dwChan >= MIN_CHANS;
+    result &= cbGetChanCaps(dwChan, &dwChanCaps, nInstance) == cbRESULT_OK;
+    result &= (dwChanCaps & cbCHAN_DINP) == cbCHAN_DINP;
+    return result;
 }
 
 
 // TRUE means yes; FALSE, no
 bool IsChanSerial(uint32_t dwChan, uint32_t nInstance)
 {
-	uint32_t dwDiginCaps;
-	bool result = IsChanAnyDigIn(dwChan, nInstance);
-	result &= cbGetDinpCaps(dwChan, &dwDiginCaps, nInstance) == cbRESULT_OK;
-	result &= (dwDiginCaps & cbDINP_SERIALMASK) == cbDINP_SERIALMASK;
-	return result;
+    uint32_t dwDiginCaps;
+    bool result = IsChanAnyDigIn(dwChan, nInstance);
+    result &= cbGetDinpCaps(dwChan, &dwDiginCaps, nInstance) == cbRESULT_OK;
+    result &= (dwDiginCaps & cbDINP_SERIALMASK) == cbDINP_SERIALMASK;
+    return result;
 }
 
 
 // TRUE means yes; FALSE, no
 bool IsChanDigin(uint32_t dwChan, uint32_t nInstance)
 {
-	uint32_t dwDiginCaps;
-	bool result = IsChanAnyDigIn(dwChan, nInstance);
-	result &= cbGetDinpCaps(dwChan, &dwDiginCaps, nInstance) == cbRESULT_OK;
-	result &= (dwDiginCaps & cbDINP_SERIALMASK) != cbDINP_SERIALMASK;
-	return result;
+    uint32_t dwDiginCaps;
+    bool result = IsChanAnyDigIn(dwChan, nInstance);
+    result &= cbGetDinpCaps(dwChan, &dwDiginCaps, nInstance) == cbRESULT_OK;
+    result &= (dwDiginCaps & cbDINP_SERIALMASK) != cbDINP_SERIALMASK;
+    return result;
 }
 
 bool IsChanDigout(uint32_t dwChan, uint32_t nInstance)
 {
-	uint32_t dwChanCaps;
-	bool result;
+    uint32_t dwChanCaps;
+    bool result;
 
-	result = dwChan >= MIN_CHANS;
-	result &= cbGetChanCaps(dwChan, &dwChanCaps, nInstance) == cbRESULT_OK;
-	result &= (dwChanCaps & cbCHAN_DOUT) == cbCHAN_DOUT;
-	return result;
+    result = dwChan >= MIN_CHANS;
+    result &= cbGetChanCaps(dwChan, &dwChanCaps, nInstance) == cbRESULT_OK;
+    result &= (dwChanCaps & cbCHAN_DOUT) == cbCHAN_DOUT;
+    return result;
 }
 
 
@@ -132,13 +132,13 @@ bool IsChanDigout(uint32_t dwChan, uint32_t nInstance)
 // Input:   nChannel - the channel ID that we want to check
 bool IsChanAnalogIn(uint32_t dwChan, uint32_t nInstance)
 {
-	uint32_t dwChanCaps;
-	bool result;
+    uint32_t dwChanCaps;
+    bool result;
 
-	result = dwChan >= MIN_CHANS;
-	result &= cbGetChanCaps(dwChan, &dwChanCaps, nInstance) == cbRESULT_OK;
-	result &= (dwChanCaps & cbCHAN_AINP) == cbCHAN_AINP;
-	return result;
+    result = dwChan >= MIN_CHANS;
+    result &= cbGetChanCaps(dwChan, &dwChanCaps, nInstance) == cbRESULT_OK;
+    result &= (dwChanCaps & cbCHAN_AINP) == cbCHAN_AINP;
+    return result;
 }
 
 
@@ -147,12 +147,12 @@ bool IsChanAnalogIn(uint32_t dwChan, uint32_t nInstance)
 // Input:   nChannel - the channel ID that we want to check
 bool IsChanFEAnalogIn(uint32_t dwChan, uint32_t nInstance)
 {
-	bool result = IsChanAnalogIn(dwChan, nInstance);
-	result &= dwChan <= MAX_CHANS_FRONT_END;  // TODO: This is not consistent on single vs double NSP systems.
-	// uint32_t dwAinpCaps;
-	// result &= cbGetAinpCaps(dwChan, &dwAinpCaps, nullptr, nullptr, nInstance);
-	// result &= (dwAinpCaps & cbAINP_??) == cbAINP_??;
-	return result;
+    bool result = IsChanAnalogIn(dwChan, nInstance);
+    result &= dwChan <= MAX_CHANS_FRONT_END;  // TODO: This is not consistent on single vs double NSP systems.
+    // uint32_t dwAinpCaps;
+    // result &= cbGetAinpCaps(dwChan, &dwAinpCaps, nullptr, nullptr, nInstance);
+    // result &= (dwAinpCaps & cbAINP_??) == cbAINP_??;
+    return result;
 }
 
 

--- a/cbhwlib/cbHwlibHi.cpp
+++ b/cbhwlib/cbHwlibHi.cpp
@@ -82,61 +82,84 @@ bool IsRawProcessingEnabled(uint32_t nChan, uint32_t nInstance)
 
 
 // TRUE means yes; FALSE, no
-bool IsChanSerial(uint32_t dwChan)
+bool IsChanAnyDigIn(uint32_t dwChan, uint32_t nInstance)
 {
-    if ((dwChan >= MIN_CHANS_SERIAL) && (dwChan <= MAX_CHANS_SERIAL))
-        return true;
+	uint32_t dwChanCaps;
+	bool result;
 
-    return false;
+	result = dwChan >= MIN_CHANS;
+	result &= cbGetChanCaps(dwChan, &dwChanCaps, nInstance) == cbRESULT_OK;
+	result &= (dwChanCaps & cbCHAN_DINP) == cbCHAN_DINP;
+	return result;
 }
 
 
 // TRUE means yes; FALSE, no
-bool IsChanDigin(uint32_t dwChan)
+bool IsChanSerial(uint32_t dwChan, uint32_t nInstance)
 {
-    if ((dwChan >= MIN_CHANS_DIGITAL_IN) && (dwChan <= MAX_CHANS_DIGITAL_IN))
-        return true;
-
-    return false;
+	uint32_t dwDiginCaps;
+	bool result = IsChanAnyDigIn(dwChan, nInstance);
+	result &= cbGetDinpCaps(dwChan, &dwDiginCaps, nInstance) == cbRESULT_OK;
+	result &= (dwDiginCaps & cbDINP_SERIALMASK) == cbDINP_SERIALMASK;
+	return result;
 }
 
-bool IsChanDigout(uint32_t dwChan)
-{
-    if ((dwChan >= MIN_CHANS_DIGITAL_OUT) && (dwChan <= MAX_CHANS_DIGITAL_OUT))
-        return true;
 
-    return false;
+// TRUE means yes; FALSE, no
+bool IsChanDigin(uint32_t dwChan, uint32_t nInstance)
+{
+	uint32_t dwDiginCaps;
+	bool result = IsChanAnyDigIn(dwChan, nInstance);
+	result &= cbGetDinpCaps(dwChan, &dwDiginCaps, nInstance) == cbRESULT_OK;
+	result &= (dwDiginCaps & cbDINP_SERIALMASK) != cbDINP_SERIALMASK;
+	return result;
+}
+
+bool IsChanDigout(uint32_t dwChan, uint32_t nInstance)
+{
+	uint32_t dwChanCaps;
+	bool result;
+
+	result = dwChan >= MIN_CHANS;
+	result &= cbGetChanCaps(dwChan, &dwChanCaps, nInstance) == cbRESULT_OK;
+	result &= (dwChanCaps & cbCHAN_DOUT) == cbCHAN_DOUT;
+	return result;
 }
 
 
 // Author & Date:   Almut Branner   15 Jan 2004
 // Purpose: Find out whether an analog in channel
 // Input:   nChannel - the channel ID that we want to check
-bool IsChanAnalogIn(uint32_t dwChan)
+bool IsChanAnalogIn(uint32_t dwChan, uint32_t nInstance)
 {
-    if ((dwChan >= MIN_CHANS) && (dwChan <= MAX_CHANS_ANALOG_IN))
-        return true;
+	uint32_t dwChanCaps;
+	bool result;
 
-    return false;
+	result = dwChan >= MIN_CHANS;
+	result &= cbGetChanCaps(dwChan, &dwChanCaps, nInstance) == cbRESULT_OK;
+	result &= (dwChanCaps & cbCHAN_AINP) == cbCHAN_AINP;
+	return result;
 }
 
 
 // Author & Date:   Almut Branner   15 Jan 2004
 // Purpose: Find out whether a channel is a Front-End analog in channel
 // Input:   nChannel - the channel ID that we want to check
-bool IsChanFEAnalogIn(uint32_t dwChan)
+bool IsChanFEAnalogIn(uint32_t dwChan, uint32_t nInstance)
 {
-    if ((dwChan >= MIN_CHANS) && (dwChan <= MAX_CHANS_FRONT_END))
-        return true;
-
-    return false;
+	bool result = IsChanAnalogIn(dwChan, nInstance);
+	result &= dwChan <= MAX_CHANS_FRONT_END;  // TODO: This is not consistent on single vs double NSP systems.
+	// uint32_t dwAinpCaps;
+	// result &= cbGetAinpCaps(dwChan, &dwAinpCaps, nullptr, nullptr, nInstance);
+	// result &= (dwAinpCaps & cbAINP_??) == cbAINP_??;
+	return result;
 }
 
 
 // Author & Date:   Almut Branner   15 Jan 2004
 // Purpose: Find out whether a channel is a Analog-In analog in channel
 // Input:   nChannel - the channel ID that we want to check
-bool IsChanAIAnalogIn(uint32_t dwChan)
+bool IsChanAIAnalogIn(uint32_t dwChan, uint32_t nInstance)
 {
     if ((dwChan >= MIN_CHANS_ANALOG_IN) && (dwChan <= MAX_CHANS_ANALOG_IN))
         return true;

--- a/cbhwlib/cbHwlibHi.h
+++ b/cbhwlib/cbHwlibHi.h
@@ -86,12 +86,13 @@ bool IsSerialEnabled(uint32_t nChannel, uint32_t nInstance = 0);
 bool IsDigitalOutEnabled(uint32_t nChannel, uint32_t nInstance = 0);
 
 // Is it "this" kind of channel? (very fast)
-bool IsChanAnalogIn(uint32_t dwChan);             // TRUE means yes; FALSE, no
-bool IsChanFEAnalogIn(uint32_t dwChan);           // TRUE means yes; FALSE, no
-bool IsChanAIAnalogIn(uint32_t dwChan);           // TRUE means yes; FALSE, no
-bool IsChanSerial(uint32_t dwChan);               // TRUE means yes; FALSE, no
-bool IsChanDigin(uint32_t dwChan);                // TRUE means yes; FALSE, no
-bool IsChanDigout(uint32_t dwChan);               // TRUE means yes; FALSE, no
+bool IsChanAnalogIn(uint32_t dwChan, uint32_t nInstance = 0);             // TRUE means yes; FALSE, no
+bool IsChanFEAnalogIn(uint32_t dwChan, uint32_t nInstance = 0);           // TRUE means yes; FALSE, no
+bool IsChanAIAnalogIn(uint32_t dwChan, uint32_t nInstance = 0);           // TRUE means yes; FALSE, no
+bool IsChanAnyDigIn(uint32_t dwChan, uint32_t nInstance = 0);  // TRUE means yes; FALSE, no
+bool IsChanSerial(uint32_t dwChan, uint32_t nInstance = 0); // TRUE means yes; FALSE, no
+bool IsChanDigin(uint32_t dwChan, uint32_t nInstance = 0);  // TRUE means yes; FALSE, no
+bool IsChanDigout(uint32_t dwChan, uint32_t nInstance = 0);               // TRUE means yes; FALSE, no
 bool IsChanCont(uint32_t dwChan, uint32_t nInstance = 0);                 // TRUE means yes; FALSE, no
 
 bool AreHoopsDefined(uint32_t nChannel, uint32_t nInstance = 0);

--- a/cbhwlib/cbhwlib.cpp
+++ b/cbhwlib/cbhwlib.cpp
@@ -1262,9 +1262,11 @@ cbRESULT cbGetAoutWaveform(uint32_t channel, uint8_t  trigNum, uint16_t  * mode,
     if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[channel - 1].chancaps & cbCHAN_AOUT)) return cbRESULT_INVALIDFUNCTION;
     if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[channel - 1].aoutcaps & cbAOUT_WAVEFORM)) return cbRESULT_INVALIDFUNCTION;
     if (trigNum >= cbMAX_AOUT_TRIGGER) return cbRESULT_INVALIDFUNCTION;
-    if (channel <= cbNUM_ANALOG_CHANS) return cbRESULT_INVALIDCHANNEL;
-    channel -= (cbNUM_ANALOG_CHANS + 1); // make it 0-based
-    if (channel >= AOUT_NUM_GAIN_CHANS) return cbRESULT_INVALIDCHANNEL;
+	// TODO: Maybe we need a m_ChanIdxInType array.
+	if (cb_cfg_buffer_ptr[nIdx]->chaninfo[cbNUM_ANALOG_CHANS - 1].chancaps & cbCHANTYPE_ANAIN)
+		channel -= (cbNUM_ANALOG_CHANS + 1); // make it 0-based
+	else
+		channel -= (128 + 16 + 1);
     if (cb_cfg_buffer_ptr[nIdx]->isWaveform[channel][trigNum].type == 0) return cbRESULT_INVALIDCHANNEL;
 
     // otherwise, return the data
@@ -2499,7 +2501,7 @@ cbRESULT cbSSGetNoiseBoundary(uint32_t chanIdx, float afCentroid[3], float afMaj
 
     // Test for prior library initialization
     if (!cb_library_initialized[nIdx]) return cbRESULT_NOLIBRARY;
-    if ((chanIdx - 1) >= cbNUM_ANALOG_CHANS) return cbRESULT_INVALIDCHANNEL;
+	if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
 
     cbPKT_SS_NOISE_BOUNDARY const & rPkt = cb_cfg_buffer_ptr[nIdx]->isSortingOptions.pktNoiseBoundary[chanIdx - 1];
     if (afCentroid)
@@ -2548,9 +2550,8 @@ cbRESULT cbSSSetNoiseBoundary(uint32_t chanIdx, float afCentroid[3], float afMaj
     uint32_t nIdx = cb_library_index[nInstance];
 
     // Test for prior library initialization
-    if (!cb_library_initialized[nIdx])
-        return cbRESULT_NOLIBRARY;
-    if ((chanIdx - 1) >= cbNUM_ANALOG_CHANS) return cbRESULT_INVALIDCHANNEL;
+    if (!cb_library_initialized[nIdx]) return cbRESULT_NOLIBRARY;
+	if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
 
     cbPKT_SS_NOISE_BOUNDARY icPkt;
     icPkt.set(chanIdx, afCentroid[0], afCentroid[1], afCentroid[2],
@@ -2576,9 +2577,8 @@ cbRESULT cbSSGetNoiseBoundaryByTheta(uint32_t chanIdx, float afCentroid[3], floa
     uint32_t nIdx = cb_library_index[nInstance];
 
     // Test for prior library initialization
-    if (!cb_library_initialized[nIdx])
-        return cbRESULT_NOLIBRARY;
-    if ((chanIdx - 1) >= cbNUM_ANALOG_CHANS) return cbRESULT_INVALIDCHANNEL;
+    if (!cb_library_initialized[nIdx]) return cbRESULT_NOLIBRARY;
+	if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
 
     // get noise boundary info
     cbPKT_SS_NOISE_BOUNDARY const & rPkt = cb_cfg_buffer_ptr[nIdx]->isSortingOptions.pktNoiseBoundary[chanIdx - 1];
@@ -2621,9 +2621,8 @@ cbRESULT cbSSSetNoiseBoundaryByTheta(uint32_t chanIdx, const float afCentroid[3]
     uint32_t nIdx = cb_library_index[nInstance];
 
     // Test for prior library initialization
-    if (!cb_library_initialized[nIdx])
-        return cbRESULT_NOLIBRARY;
-    if ((chanIdx - 1) >= cbNUM_ANALOG_CHANS) return cbRESULT_INVALIDCHANNEL;
+    if (!cb_library_initialized[nIdx]) return cbRESULT_NOLIBRARY;
+	if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
 
     // TODO: must be implemented for non MSC
 #ifndef QT_APP

--- a/cbhwlib/cbhwlib.cpp
+++ b/cbhwlib/cbhwlib.cpp
@@ -1262,11 +1262,11 @@ cbRESULT cbGetAoutWaveform(uint32_t channel, uint8_t  trigNum, uint16_t  * mode,
     if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[channel - 1].chancaps & cbCHAN_AOUT)) return cbRESULT_INVALIDFUNCTION;
     if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[channel - 1].aoutcaps & cbAOUT_WAVEFORM)) return cbRESULT_INVALIDFUNCTION;
     if (trigNum >= cbMAX_AOUT_TRIGGER) return cbRESULT_INVALIDFUNCTION;
-	// TODO: Maybe we need a m_ChanIdxInType array.
-	if (cb_cfg_buffer_ptr[nIdx]->chaninfo[cbNUM_ANALOG_CHANS - 1].chancaps & cbCHANTYPE_ANAIN)
-		channel -= (cbNUM_ANALOG_CHANS + 1); // make it 0-based
-	else
-		channel -= (128 + 16 + 1);
+    // TODO: Maybe we need a m_ChanIdxInType array.
+    if (cb_cfg_buffer_ptr[nIdx]->chaninfo[cbNUM_ANALOG_CHANS - 1].chancaps & cbCHANTYPE_ANAIN)
+        channel -= (cbNUM_ANALOG_CHANS + 1); // make it 0-based
+    else
+        channel -= (128 + cbNUM_ANAIN_CHANS + 1);
     if (cb_cfg_buffer_ptr[nIdx]->isWaveform[channel][trigNum].type == 0) return cbRESULT_INVALIDCHANNEL;
 
     // otherwise, return the data
@@ -1796,7 +1796,7 @@ cbRESULT cbGetDoutCaps(uint32_t chan, uint32_t *doutcaps, uint32_t nInstance)
 // Purpose: Digital Output Inquiry and Configuration Functions
 //
 cbRESULT cbGetDoutOptions(uint32_t chan, uint32_t *options, uint32_t *monchan, uint32_t *value,
-						  uint8_t *triggertype, uint16_t *trigchan, uint16_t *trigval, uint32_t nInstance)
+                          uint8_t *triggertype, uint16_t *trigchan, uint16_t *trigval, uint32_t nInstance)
 {
     uint32_t nIdx = cb_library_index[nInstance];
 
@@ -1844,7 +1844,7 @@ cbRESULT cbSetDoutOptions(uint32_t chan, uint32_t options, uint32_t monchan, uin
     chaninfo.doutopts  = options;
     chaninfo.monsource = monchan;
     chaninfo.outvalue  = value;
-    chaninfo.trigtype  = triggertype;	
+    chaninfo.trigtype  = triggertype;
     chaninfo.trigchan  = trigchan;
     chaninfo.trigval   = trigval;
 
@@ -2501,7 +2501,7 @@ cbRESULT cbSSGetNoiseBoundary(uint32_t chanIdx, float afCentroid[3], float afMaj
 
     // Test for prior library initialization
     if (!cb_library_initialized[nIdx]) return cbRESULT_NOLIBRARY;
-	if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
+    if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
 
     cbPKT_SS_NOISE_BOUNDARY const & rPkt = cb_cfg_buffer_ptr[nIdx]->isSortingOptions.pktNoiseBoundary[chanIdx - 1];
     if (afCentroid)
@@ -2551,7 +2551,7 @@ cbRESULT cbSSSetNoiseBoundary(uint32_t chanIdx, float afCentroid[3], float afMaj
 
     // Test for prior library initialization
     if (!cb_library_initialized[nIdx]) return cbRESULT_NOLIBRARY;
-	if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
+    if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
 
     cbPKT_SS_NOISE_BOUNDARY icPkt;
     icPkt.set(chanIdx, afCentroid[0], afCentroid[1], afCentroid[2],
@@ -2578,7 +2578,7 @@ cbRESULT cbSSGetNoiseBoundaryByTheta(uint32_t chanIdx, float afCentroid[3], floa
 
     // Test for prior library initialization
     if (!cb_library_initialized[nIdx]) return cbRESULT_NOLIBRARY;
-	if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
+    if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
 
     // get noise boundary info
     cbPKT_SS_NOISE_BOUNDARY const & rPkt = cb_cfg_buffer_ptr[nIdx]->isSortingOptions.pktNoiseBoundary[chanIdx - 1];
@@ -2622,7 +2622,7 @@ cbRESULT cbSSSetNoiseBoundaryByTheta(uint32_t chanIdx, const float afCentroid[3]
 
     // Test for prior library initialization
     if (!cb_library_initialized[nIdx]) return cbRESULT_NOLIBRARY;
-	if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
+    if (!(cb_cfg_buffer_ptr[nIdx]->chaninfo[chanIdx - 1].chancaps & cbCHAN_AINP)) return cbRESULT_INVALIDCHANNEL;
 
     // TODO: must be implemented for non MSC
 #ifndef QT_APP

--- a/cbhwlib/cbhwlib.h
+++ b/cbhwlib/cbhwlib.h
@@ -240,7 +240,7 @@ typedef uint8_t DLEN;
 #define cbNUM_SERIAL_CHANS    1                                         // #Serial Input channels
 #define cbNUM_DIGOUT_CHANS    4                                         // #Digital Output channels
 
-// Total of all channels = 156
+// Total of all channels = 284
 #define cbMAXCHANS            (cbNUM_ANALOG_CHANS +  cbNUM_ANALOGOUT_CHANS + cbNUM_DIGIN_CHANS + cbNUM_SERIAL_CHANS + cbNUM_DIGOUT_CHANS)
 
 // #define cbFIRST_FE_CHAN       0                                          // 0   First Front end channel
@@ -250,6 +250,15 @@ typedef uint8_t DLEN;
 // #define cbFIRST_DIGIN_CHAN    (cbFIRST_AUDOUT_CHAN + cbNUM_AUDOUT_CHANS) // 300 First Digital Input channel
 // #define cbFIRST_SERIAL_CHAN   (cbFIRST_DIGIN_CHAN + cbNUM_DIGIN_CHANS)   // 302 First Serial Input channel
 // #define cbFIRST_DIGOUT_CHAN   (cbFIRST_SERIAL_CHAN + cbNUM_SERIAL_CHANS) // 304 First Digital Output channel
+
+// Channel type definitions. Used by SdkApp to store the channel type for each channel on the instrument.
+// Uses uint8_t
+#define cbCHANTYPE_ANAIN  0x01
+#define cbCHANTYPE_ANAOUT 0x02
+#define cbCHANTYPE_AUDOUT 0x04
+#define cbCHANTYPE_DIGIN  0x10
+#define cbCHANTYPE_SERIAL 0x20
+#define cbCHANTYPE_DIGOUT 0x40
 
 // Bank definitions - NOTE: If any of the channel types have more than cbCHAN_PER_BANK channels, the banks must be increased accordingly
 #define cbCHAN_PER_BANK       32                                         // number of 32 channel banks == 1024
@@ -2774,7 +2783,7 @@ typedef struct {
     uint8_t type;      // cbPKTTYPE_WAVEFORMREP or cbPKTTYPE_WAVEFORMSET depending on direction
     uint8_t dlen;      // packet size
 
-    uint16_t chan;        // which analog output/audio output channel (1-based, will equal chan from GetDoutCaps)
+    uint16_t chan;        // which analog output/audio output channel (1-based, will equal chan from GetAoutCaps)
 
     // Each file may contain multiple sequences.
     // Each sequence consists of phases

--- a/cbmex/SdkApp.h
+++ b/cbmex/SdkApp.h
@@ -74,6 +74,7 @@ public:
                                   bool bAbsolute);
     cbSdkResult SdkGetChannelLabel(uint16_t channel, uint32_t * bValid, char * label, uint32_t * userflags, int32_t * position);
     cbSdkResult SdkSetChannelLabel(uint16_t channel, const char * label, uint32_t userflags, int32_t * position);
+	cbSdkResult SdkGetChannelType(uint16_t channel, uint8_t * chtype);
     cbSdkResult SdkGetTrialData(uint32_t bActive, cbSdkTrialEvent * trialevent, cbSdkTrialCont * trialcont,
                                 cbSdkTrialComment * trialcomment, cbSdkTrialTracking * trialtracking);
     cbSdkResult SdkInitTrialData(uint32_t bActive, cbSdkTrialEvent* trialevent, cbSdkTrialCont * trialcont,
@@ -205,18 +206,25 @@ private:
     // Structure to store all of the variables associated with the event data
     struct EventData
     {
+		// We use cbMAXCHANS to size the arrays,
+		// even though that's more than the analog + digin + serial channels than are required,
+		// simply so we can index into these arrays using the channel number (-1).
+		// The alternative is to map between channel number and array index, but
+		// this is problematic with the recent change to 2-NSP support.
+		// Later I may add a m_ChIdxInType or m_ChIdxInBuff for such a map.
+		// - chadwick.boulay@gmail.com
         uint32_t size; // default is cbSdk_EVENT_DATA_SAMPLES
-        uint32_t * timestamps[cbNUM_ANALOG_CHANS + 2];
-        uint16_t * units[cbNUM_ANALOG_CHANS + 2];
+        uint32_t * timestamps[cbMAXCHANS];
+        uint16_t * units[cbMAXCHANS];
         int16_t  * waveform_data; // buffer with maximum size of array [cbNUM_ANALOG_CHANS][size][cbMAX_PNTS]
-        uint32_t write_index[cbNUM_ANALOG_CHANS + 2];                  // next index location to write data
-        uint32_t write_start_index[cbNUM_ANALOG_CHANS + 2];            // index location that writing began
+        uint32_t write_index[cbMAXCHANS];                  // next index location to write data
+        uint32_t write_start_index[cbMAXCHANS];            // index location that writing began
 
         void reset()
         {
             if (size)
             {
-                for (uint32_t i = 0; i < cbNUM_ANALOG_CHANS + 2; ++i)
+                for (uint32_t i = 0; i < cbMAXCHANS; ++i)
                 {
                     memset(timestamps[i], 0, size * sizeof(uint32_t));
                     memset(units[i], 0, size * sizeof(uint16_t));

--- a/cbmex/SdkApp.h
+++ b/cbmex/SdkApp.h
@@ -206,13 +206,13 @@ private:
     // Structure to store all of the variables associated with the event data
     struct EventData
     {
-		// We use cbMAXCHANS to size the arrays,
-		// even though that's more than the analog + digin + serial channels than are required,
-		// simply so we can index into these arrays using the channel number (-1).
-		// The alternative is to map between channel number and array index, but
-		// this is problematic with the recent change to 2-NSP support.
-		// Later I may add a m_ChIdxInType or m_ChIdxInBuff for such a map.
-		// - chadwick.boulay@gmail.com
+        // We use cbMAXCHANS to size the arrays,
+        // even though that's more than the analog + digin + serial channels than are required,
+        // simply so we can index into these arrays using the channel number (-1).
+        // The alternative is to map between channel number and array index, but
+        // this is problematic with the recent change to 2-NSP support.
+        // Later I may add a m_ChIdxInType or m_ChIdxInBuff for such a map.
+        // - chadwick.boulay@gmail.com
         uint32_t size; // default is cbSdk_EVENT_DATA_SAMPLES
         uint32_t * timestamps[cbMAXCHANS];
         uint16_t * units[cbMAXCHANS];

--- a/cbmex/cbsdk.cpp
+++ b/cbmex/cbsdk.cpp
@@ -213,13 +213,13 @@ void SdkApp::OnPktEvent(const cbPKT_GENERIC * const pPkt)
                 m_ED->write_index[ch] = new_write_index;
 
                 if (m_bPacketsEvent)
-                {	
+                {
                     m_lockGetPacketsEvent.lock();
                         if (pPkt->time > m_uTrialStartTime)
                         {
                             m_bPacketsEvent = FALSE;
                             m_waitPacketsEvent.wakeAll();
-                        }						
+                        }
                     m_lockGetPacketsEvent.unlock();
                 }
             }
@@ -281,14 +281,13 @@ void SdkApp::OnPktComment(const cbPKT_COMMENT * const pPkt)
                 m_CMT->write_index = new_write_index;
 
                 if (m_bPacketsCmt)
-                {	
-
+                {
                     m_lockGetPacketsCmt.lock();
                         if (pPkt->time > m_uTrialStartTime)
                         {
                             m_bPacketsCmt = FALSE;
                             m_waitPacketsCmt.wakeAll();
-                        }						
+                        }
                     m_lockGetPacketsCmt.unlock();
                 }
             }
@@ -328,14 +327,13 @@ void SdkApp::OnPktLog(const cbPKT_LOG * const pPkt)
                 m_CMT->write_index = new_write_index;
 
                 if (m_bPacketsCmt)
-                {	
-
+                {
                     m_lockGetPacketsCmt.lock();
                         if (pPkt->time > m_uTrialStartTime)
                         {
                             m_bPacketsCmt = FALSE;
                             m_waitPacketsCmt.wakeAll();
-                        }						
+                        }
                     m_lockGetPacketsCmt.unlock();
                 }
             }
@@ -425,14 +423,13 @@ void SdkApp::OnPktTrack(const cbPKT_VIDEOTRACK * const pPkt)
                 m_TR->write_index[id] = new_write_index;
 
                 if (m_bPacketsTrack)
-                {	
-
+                {
                     m_lockGetPacketsTrack.lock();
                         if (pPkt->time > m_uTrialStartTime)
                         {
                             m_bPacketsTrack = FALSE;
                             m_waitPacketsTrack.wakeAll();
-                        }						
+                        }
                     m_lockGetPacketsTrack.unlock();
                 }
             }
@@ -1086,7 +1083,7 @@ cbSdkResult SdkApp::unsetTrialConfig(cbSdkTrialType type)
     case CBSDKTRIAL_EVENTS:
         if (m_ED == NULL)
             return CBSDKRESULT_ERRCONFIG;
-		// TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
+        // TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
         for (uint32_t i = 0; i < cbMAXCHANS; ++i)
         {
             if (m_ED->timestamps[i])
@@ -1468,8 +1465,8 @@ cbSdkResult SdkApp::SdkSetTrialConfig(uint32_t bActive, uint16_t begchan, uint32
             m_ED->size = uEvents;
             bool bErr = false;
             try {
-				// TODO: Go back to using cbNUM_ANALOG_CHANS + 2 once we have a ChIdxInType map
-				// for indexing m_ED while processing packets.
+                // TODO: Go back to using cbNUM_ANALOG_CHANS + 2 once we have a ChIdxInType map
+                // for indexing m_ED while processing packets.
                 for (uint32_t i = 0; i < cbMAXCHANS; ++i)
                 {
                     m_ED->timestamps[i] = new uint32_t[m_ED->size];
@@ -1700,14 +1697,14 @@ cbSdkResult SdkApp::SdkGetChannelLabel(uint16_t channel, uint32_t * bValid, char
         for (int i = 0; i < 6; ++i)
             bValid[i] = 0;
         cbHOOP hoops[cbMAXUNITS][cbMAXHOOPS];
-		if (m_ChannelType[channel-1] == cbCHANTYPE_ANAIN)
+        if (m_ChannelType[channel-1] == cbCHANTYPE_ANAIN)
         {
             cbGetAinpSpikeHoops(channel, &hoops[0][0], m_nInstance);
             bValid[0] = IsSpikeProcessingEnabled(channel);
             for (int i = 0; i < cbMAXUNITS; ++i)
                 bValid[i + 1] = hoops[i][0].valid;
         }
-		else if ((m_ChannelType[channel - 1] == cbCHANTYPE_DIGIN) || (m_ChannelType[channel - 1] == cbCHANTYPE_SERIAL))
+        else if ((m_ChannelType[channel - 1] == cbCHANTYPE_DIGIN) || (m_ChannelType[channel - 1] == cbCHANTYPE_SERIAL))
         {
             uint32_t options;
             cbGetDinpOptions(channel, &options, NULL, m_nInstance);
@@ -1773,24 +1770,24 @@ CBSDKAPI    cbSdkResult cbSdkSetChannelLabel(uint32_t nInstance,
 
 cbSdkResult SdkApp::SdkGetChannelType(uint16_t channel, uint8_t * chType)
 {
-	if (m_instInfo == 0)
-		return CBSDKRESULT_CLOSED;
+    if (m_instInfo == 0)
+        return CBSDKRESULT_CLOSED;
 
-	*chType = m_ChannelType[channel - 1];
-	return CBSDKRESULT_SUCCESS;
+    *chType = m_ChannelType[channel - 1];
+    return CBSDKRESULT_SUCCESS;
 }
 
 CBSDKAPI    cbSdkResult cbSdkGetChannelType(uint32_t nInstance, uint16_t channel, uint8_t *chType)
 {
-	if (channel == 0 || channel > cbMAXCHANS)
-		return CBSDKRESULT_INVALIDCHANNEL;
-	if (chType == NULL)
-		return CBSDKRESULT_NULLPTR;
-	if (nInstance >= cbMAXOPEN)
-		return CBSDKRESULT_INVALIDPARAM;
-	if (g_app[nInstance] == NULL)
-		return CBSDKRESULT_CLOSED;
-	return g_app[nInstance]->SdkGetChannelType(channel, chType);
+    if (channel == 0 || channel > cbMAXCHANS)
+        return CBSDKRESULT_INVALIDCHANNEL;
+    if (chType == NULL)
+        return CBSDKRESULT_NULLPTR;
+    if (nInstance >= cbMAXOPEN)
+        return CBSDKRESULT_INVALIDPARAM;
+    if (g_app[nInstance] == NULL)
+        return CBSDKRESULT_CLOSED;
+    return g_app[nInstance]->SdkGetChannelType(channel, chType);
 }
 
 // Author & Date:   Ehsan Azar     11 March 2011
@@ -1894,15 +1891,15 @@ cbSdkResult SdkApp::SdkGetTrialData(uint32_t bActive, cbSdkTrialEvent * trialeve
 
     if (trialevent)
     {
-		// TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
+        // TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
         uint32_t read_end_index[cbMAXCHANS];
         uint32_t read_start_index[cbMAXCHANS];
         if (m_ED == NULL)
             return CBSDKRESULT_ERRCONFIG;
         
-		// Determine how many samples to copy on this iteration.
-		// We will copy the minimum among (write_index-write_start_index) and
-		// trialevent->num_samples which should correspond to the number of allocated samples.
+        // Determine how many samples to copy on this iteration.
+        // We will copy the minimum among (write_index-write_start_index) and
+        // trialevent->num_samples which should correspond to the number of allocated samples.
         memcpy(read_start_index, m_ED->write_start_index, sizeof(read_start_index));
         m_lockTrialEvent.lock();
         memcpy(read_end_index, m_ED->write_index, sizeof(read_end_index));
@@ -1912,7 +1909,7 @@ cbSdkResult SdkApp::SdkGetTrialData(uint32_t bActive, cbSdkTrialEvent * trialeve
         for (uint32_t ev_ix = 0; ev_ix < trialevent->count; ev_ix++)
         {
             uint16_t ch = trialevent->chan[ev_ix]; // channel number, 1-based
-			if ((m_ChannelType[ch - 1] != cbCHANTYPE_ANAIN) && (m_ChannelType[ch - 1] != cbCHANTYPE_DIGIN) && (m_ChannelType[ch - 1] != cbCHANTYPE_SERIAL))
+            if ((m_ChannelType[ch - 1] != cbCHANTYPE_ANAIN) && (m_ChannelType[ch - 1] != cbCHANTYPE_DIGIN) && (m_ChannelType[ch - 1] != cbCHANTYPE_SERIAL))
                 return CBSDKRESULT_INVALIDCHANNEL;
             // Ignore masked channels
             if (!m_bChannelMask[ch - 1])
@@ -1922,18 +1919,18 @@ cbSdkResult SdkApp::SdkGetTrialData(uint32_t bActive, cbSdkTrialEvent * trialeve
             }
 
             uint32_t read_index = m_ED->write_start_index[ch - 1];
-			int num_samples = read_end_index[ch - 1] - read_index;
+            int num_samples = read_end_index[ch - 1] - read_index;
             if (num_samples < 0)
                 num_samples += m_ED->size;
 
-			// We don't know for sure how many samples were allocated,
-			// but this is what the client application was told to allocate.
-			uint32_t num_allocated = 0;
-			for (int unit_ix = 0; unit_ix < cbMAXUNITS; unit_ix++)
-			{
-				num_allocated += trialevent->num_samples[ev_ix][unit_ix];
-			}
-			num_samples = std::min((uint32_t)num_samples, num_allocated);
+            // We don't know for sure how many samples were allocated,
+            // but this is what the client application was told to allocate.
+            uint32_t num_allocated = 0;
+            for (int unit_ix = 0; unit_ix < cbMAXUNITS; unit_ix++)
+            {
+                num_allocated += trialevent->num_samples[ev_ix][unit_ix];
+            }
+            num_samples = std::min((uint32_t)num_samples, num_allocated);
 
             uint32_t num_samples_unit[cbMAXUNITS + 1];  // To keep track of how many samples are copied per unit.
             memset(num_samples_unit, 0, sizeof(num_samples_unit));
@@ -1942,57 +1939,57 @@ cbSdkResult SdkApp::SdkGetTrialData(uint32_t bActive, cbSdkTrialEvent * trialeve
             {
                 uint16_t unit = m_ED->units[ch - 1][read_index];  // pktType for anain, or the first data value for dig/serial.
 
-				// For digital or serial data, 'unit' holds data, and is not indicating the unit number.
-				// So here we copy the data to trialevent->waveforms, then set unit to 0.
-				if ((m_ChannelType[ch - 1] == cbCHANTYPE_DIGIN) || (m_ChannelType[ch - 1] == cbCHANTYPE_SERIAL))
-				{
-					if (num_samples_unit[0] < trialevent->num_samples[ev_ix][0])
-					{
-						void * dataptr = trialevent->waveforms[ev_ix];
-						// Null means ignore
-						if (dataptr)
-						{
-							if (m_bTrialDouble)
-								*((double *)dataptr + num_samples_unit[0]) = unit;
-							else
-								*((uint16_t *)dataptr + num_samples_unit[0]) = unit;
-						}
-					}
-					unit = 0;
-				}
+                // For digital or serial data, 'unit' holds data, and is not indicating the unit number.
+                // So here we copy the data to trialevent->waveforms, then set unit to 0.
+                if ((m_ChannelType[ch - 1] == cbCHANTYPE_DIGIN) || (m_ChannelType[ch - 1] == cbCHANTYPE_SERIAL))
+                {
+                    if (num_samples_unit[0] < trialevent->num_samples[ev_ix][0])
+                    {
+                        void * dataptr = trialevent->waveforms[ev_ix];
+                        // Null means ignore
+                        if (dataptr)
+                        {
+                            if (m_bTrialDouble)
+                                *((double *)dataptr + num_samples_unit[0]) = unit;
+                            else
+                                *((uint16_t *)dataptr + num_samples_unit[0]) = unit;
+                        }
+                    }
+                    unit = 0;
+                }
 
-				// Timestamps
-				if (unit <= cbMAXUNITS + 1)     // remove noise unit. why?
-				{
-					if (num_samples_unit[unit] < trialevent->num_samples[ev_ix][unit])
-					{
-						void * dataptr = trialevent->timestamps[ev_ix][unit];
-						// Null means ignore
-						if (dataptr)
-						{
-							uint32_t ts = m_ED->timestamps[ch - 1][read_index];
-							// If time wraps or due to reset, time will restart amidst trial
-							if (!m_bTrialAbsolute && ts >= prevStartTime)
-								ts -= prevStartTime;
-							if (m_bTrialDouble)
-								*((double *)dataptr + num_samples_unit[unit]) = cbSdk_SECONDS_PER_TICK * ts;
-							else
-								*((uint32_t *)dataptr + num_samples_unit[unit]) = ts;
-						}
-						num_samples_unit[unit]++;
-						
-						// Increment the read index.
-						read_index++;
-						if (read_index >= m_ED->size)
-							read_index = 0;
-					} 
+                // Timestamps
+                if (unit <= cbMAXUNITS + 1)     // remove noise unit. why?
+                {
+                    if (num_samples_unit[unit] < trialevent->num_samples[ev_ix][unit])
+                    {
+                        void * dataptr = trialevent->timestamps[ev_ix][unit];
+                        // Null means ignore
+                        if (dataptr)
+                        {
+                            uint32_t ts = m_ED->timestamps[ch - 1][read_index];
+                            // If time wraps or due to reset, time will restart amidst trial
+                            if (!m_bTrialAbsolute && ts >= prevStartTime)
+                                ts -= prevStartTime;
+                            if (m_bTrialDouble)
+                                *((double *)dataptr + num_samples_unit[unit]) = cbSdk_SECONDS_PER_TICK * ts;
+                            else
+                                *((uint32_t *)dataptr + num_samples_unit[unit]) = ts;
+                        }
+                        num_samples_unit[unit]++;
+                        
+                        // Increment the read index.
+                        read_index++;
+                        if (read_index >= m_ED->size)
+                            read_index = 0;
+                    } 
                 }
             }
             
-			// retrieved number of samples
+            // retrieved number of samples
             memcpy(trialevent->num_samples[ev_ix], num_samples_unit, sizeof(num_samples_unit));
             
-			// Flush the buffer and start a new 'trial'...
+            // Flush the buffer and start a new 'trial'...
             if (bActive)
                 read_start_index[ch - 1] = read_index;
         }
@@ -2231,7 +2228,7 @@ cbSdkResult SdkApp::SdkInitTrialData(uint32_t bActive, cbSdkTrialEvent * trialev
             m_bPacketsEvent = TRUE;
             m_lockGetPacketsEvent.unlock();
 
-			// TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
+            // TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
             uint32_t read_end_index[cbMAXCHANS];
             // Take a snapshot of the current write pointer
             m_lockTrialEvent.lock();
@@ -2315,7 +2312,7 @@ cbSdkResult SdkApp::SdkInitTrialData(uint32_t bActive, cbSdkTrialEvent * trialev
             // Wait for packets to come in
             m_lockGetPacketsCmt.lock();
             m_bPacketsCmt = TRUE;
-            m_waitPacketsCmt.wait(&m_lockGetPacketsCmt, 250);		
+            m_waitPacketsCmt.wait(&m_lockGetPacketsCmt, 250);
             m_lockGetPacketsCmt.unlock();
 
             // Take a snapshot of the current write pointer
@@ -2353,7 +2350,7 @@ cbSdkResult SdkApp::SdkInitTrialData(uint32_t bActive, cbSdkTrialEvent * trialev
             // Wait for packets to come in
             m_lockGetPacketsTrack.lock();
             m_bPacketsTrack = TRUE;
-            m_waitPacketsTrack.wait(&m_lockGetPacketsTrack, 250);		
+            m_waitPacketsTrack.wait(&m_lockGetPacketsTrack, 250);
             m_lockGetPacketsTrack.unlock();
 
             // Take a snapshot of the current write pointer
@@ -3995,7 +3992,7 @@ void SdkApp::ProcessIncomingPacket(const cbPKT_GENERIC * const pPkt)
 
     // This callback type needs to be bound only once
     LateBindCallback(CBSDKCALLBACK_ALL);
-	bool b_checkEvent = false;
+    bool b_checkEvent = false;
 
     // check for configuration class packets
     if (pPkt->chid & cbPKTCHAN_CONFIGURATION)
@@ -4128,48 +4125,48 @@ void SdkApp::ProcessIncomingPacket(const cbPKT_GENERIC * const pPkt)
                 m_pLateCallback[CBSDKCALLBACK_CONTINUOUS](m_nInstance, cbSdkPkt_CONTINUOUS, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_CONTINUOUS]);
         }
     }
-	// check for channel event packets cerebus channels 1-272
-	else if (m_ChannelType[pPkt->chid-1] == cbCHANTYPE_ANAIN) // channels are 1-based, m_ChannelType is 0-based.
-	{
-		if (m_bChannelMask[pPkt->chid - 1])
-		{
-			b_checkEvent = true;
-			if (m_pLateCallback[CBSDKCALLBACK_ALL])
-				m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_SPIKE, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
-			// Late bind before usage
-			LateBindCallback(CBSDKCALLBACK_SPIKE);
-			if (m_pLateCallback[CBSDKCALLBACK_SPIKE])
-				m_pLateCallback[CBSDKCALLBACK_SPIKE](m_nInstance, cbSdkPkt_SPIKE, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_SPIKE]);
-		}
-	}
-	// catch digital input port events and save them as NSAS experiment event packets
-	else if (m_ChannelType[pPkt->chid - 1] == cbCHANTYPE_DIGIN)
-	{
-		if (m_bChannelMask[pPkt->chid - 1])
-		{
-			b_checkEvent = true;
-			if (m_pLateCallback[CBSDKCALLBACK_ALL])
-				m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_DIGITAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
-			// Late bind before usage
-			LateBindCallback(CBSDKCALLBACK_DIGITAL);
-			if (m_pLateCallback[CBSDKCALLBACK_DIGITAL])
-				m_pLateCallback[CBSDKCALLBACK_DIGITAL](m_nInstance, cbSdkPkt_DIGITAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_DIGITAL]);
-		}
-	}
-	// catch serial input port events and save them as NSAS experiment event packets
-	else if (m_ChannelType[pPkt->chid - 1] == cbCHANTYPE_SERIAL)
-	{
-		if (m_bChannelMask[pPkt->chid - 1])
-		{
-			b_checkEvent = true;
-			if (m_pLateCallback[CBSDKCALLBACK_ALL])
-				m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_SERIAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
-			// Late bind before usage
-			LateBindCallback(CBSDKCALLBACK_SERIAL);
-			if (m_pLateCallback[CBSDKCALLBACK_SERIAL])
-				m_pLateCallback[CBSDKCALLBACK_SERIAL](m_nInstance, cbSdkPkt_SERIAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_SERIAL]);
-		}
-	}
+    // check for channel event packets cerebus channels 1-272
+    else if (m_ChannelType[pPkt->chid-1] == cbCHANTYPE_ANAIN) // channels are 1-based, m_ChannelType is 0-based.
+    {
+        if (m_bChannelMask[pPkt->chid - 1])
+        {
+            b_checkEvent = true;
+            if (m_pLateCallback[CBSDKCALLBACK_ALL])
+                m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_SPIKE, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
+            // Late bind before usage
+            LateBindCallback(CBSDKCALLBACK_SPIKE);
+            if (m_pLateCallback[CBSDKCALLBACK_SPIKE])
+                m_pLateCallback[CBSDKCALLBACK_SPIKE](m_nInstance, cbSdkPkt_SPIKE, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_SPIKE]);
+        }
+    }
+    // catch digital input port events and save them as NSAS experiment event packets
+    else if (m_ChannelType[pPkt->chid - 1] == cbCHANTYPE_DIGIN)
+    {
+        if (m_bChannelMask[pPkt->chid - 1])
+        {
+            b_checkEvent = true;
+            if (m_pLateCallback[CBSDKCALLBACK_ALL])
+                m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_DIGITAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
+            // Late bind before usage
+            LateBindCallback(CBSDKCALLBACK_DIGITAL);
+            if (m_pLateCallback[CBSDKCALLBACK_DIGITAL])
+                m_pLateCallback[CBSDKCALLBACK_DIGITAL](m_nInstance, cbSdkPkt_DIGITAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_DIGITAL]);
+        }
+    }
+    // catch serial input port events and save them as NSAS experiment event packets
+    else if (m_ChannelType[pPkt->chid - 1] == cbCHANTYPE_SERIAL)
+    {
+        if (m_bChannelMask[pPkt->chid - 1])
+        {
+            b_checkEvent = true;
+            if (m_pLateCallback[CBSDKCALLBACK_ALL])
+                m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_SERIAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
+            // Late bind before usage
+            LateBindCallback(CBSDKCALLBACK_SERIAL);
+            if (m_pLateCallback[CBSDKCALLBACK_SERIAL])
+                m_pLateCallback[CBSDKCALLBACK_SERIAL](m_nInstance, cbSdkPkt_SERIAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_SERIAL]);
+        }
+    }
     
     // save the timestamp to overcome the case where the reset button is pressed
     // (or recording started) which resets the timestamp to 0, but Central doesn't

--- a/cbmex/cbsdk.cpp
+++ b/cbmex/cbsdk.cpp
@@ -84,7 +84,7 @@ BOOL APIENTRY DllMain( HMODULE hModule,
 
 // Author & Date:   Kirk Korver     03 Aug 2005
 
-/** Called when a Sample Group packet (aka continuous data point or LPF) comes in.
+/** Called when a Sample Group packet (aka continuous data point or LFP) comes in.
 *
 * @param[in] pkt the sample group packet
 */
@@ -190,10 +190,6 @@ void SdkApp::OnPktEvent(const cbPKT_GENERIC * const pPkt)
         bool bOverFlow = false;
 
         uint16_t ch = pPkt->chid - 1;
-        if (pPkt->chid == MAX_CHANS_DIGITAL_IN)
-            ch = cbNUM_ANALOG_CHANS;
-        else if (pPkt->chid == MAX_CHANS_SERIAL)
-            ch = cbNUM_ANALOG_CHANS + 1;
 
         m_lockTrialEvent.lock();
         // double check if buffer is still valid
@@ -210,15 +206,14 @@ void SdkApp::OnPktEvent(const cbPKT_GENERIC * const pPkt)
             {
                 // Store more data
                 m_ED->timestamps[ch][old_write_index] = pPkt->time;
-                if (pPkt->chid == MAX_CHANS_DIGITAL_IN || pPkt->chid == MAX_CHANS_SERIAL)
-                    m_ED->units[ch][old_write_index] = (uint16_t)(pPkt->data[0] & 0x0000ffff);
+                if ((m_ChannelType[ch] == cbCHANTYPE_DIGIN) || (m_ChannelType[ch] == cbCHANTYPE_SERIAL))
+                    m_ED->units[ch][old_write_index] = (uint16_t)(pPkt->data[0] & 0x0000ffff);  // Store the 0th data sample (truncated to 16-bit).
                 else
-                    m_ED->units[ch][old_write_index] = pPkt->type;
+                    m_ED->units[ch][old_write_index] = pPkt->type; // Store the type.
                 m_ED->write_index[ch] = new_write_index;
 
                 if (m_bPacketsEvent)
                 {	
-
                     m_lockGetPacketsEvent.lock();
                         if (pPkt->time > m_uTrialStartTime)
                         {
@@ -227,7 +222,6 @@ void SdkApp::OnPktEvent(const cbPKT_GENERIC * const pPkt)
                         }						
                     m_lockGetPacketsEvent.unlock();
                 }
-
             }
             else if (m_bChannelMask[pPkt->chid - 1])
                 bOverFlow = true;
@@ -236,7 +230,7 @@ void SdkApp::OnPktEvent(const cbPKT_GENERIC * const pPkt)
 
         if (bOverFlow)
         {
-            /// \todo trial continuous buffer overflow event
+            /// \todo trial event buffer overflow event
         }
     }
 
@@ -1092,7 +1086,8 @@ cbSdkResult SdkApp::unsetTrialConfig(cbSdkTrialType type)
     case CBSDKTRIAL_EVENTS:
         if (m_ED == NULL)
             return CBSDKRESULT_ERRCONFIG;
-        for (uint32_t i = 0; i < cbNUM_ANALOG_CHANS + 2; ++i)
+		// TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
+        for (uint32_t i = 0; i < cbMAXCHANS; ++i)
         {
             if (m_ED->timestamps[i])
             {
@@ -1473,7 +1468,9 @@ cbSdkResult SdkApp::SdkSetTrialConfig(uint32_t bActive, uint16_t begchan, uint32
             m_ED->size = uEvents;
             bool bErr = false;
             try {
-                for (uint32_t i = 0; i < cbNUM_ANALOG_CHANS + 2; ++i)
+				// TODO: Go back to using cbNUM_ANALOG_CHANS + 2 once we have a ChIdxInType map
+				// for indexing m_ED while processing packets.
+                for (uint32_t i = 0; i < cbMAXCHANS; ++i)
                 {
                     m_ED->timestamps[i] = new uint32_t[m_ED->size];
                     m_ED->units[i] = new uint16_t[m_ED->size];
@@ -1703,14 +1700,14 @@ cbSdkResult SdkApp::SdkGetChannelLabel(uint16_t channel, uint32_t * bValid, char
         for (int i = 0; i < 6; ++i)
             bValid[i] = 0;
         cbHOOP hoops[cbMAXUNITS][cbMAXHOOPS];
-        if (channel <= cbNUM_ANALOG_CHANS)
+		if (m_ChannelType[channel-1] == cbCHANTYPE_ANAIN)
         {
             cbGetAinpSpikeHoops(channel, &hoops[0][0], m_nInstance);
             bValid[0] = IsSpikeProcessingEnabled(channel);
             for (int i = 0; i < cbMAXUNITS; ++i)
                 bValid[i + 1] = hoops[i][0].valid;
         }
-        else if ( (channel == MAX_CHANS_DIGITAL_IN) || (channel == MAX_CHANS_SERIAL) )
+		else if ((m_ChannelType[channel - 1] == cbCHANTYPE_DIGIN) || (m_ChannelType[channel - 1] == cbCHANTYPE_SERIAL))
         {
             uint32_t options;
             cbGetDinpOptions(channel, &options, NULL, m_nInstance);
@@ -1774,6 +1771,28 @@ CBSDKAPI    cbSdkResult cbSdkSetChannelLabel(uint32_t nInstance,
     return g_app[nInstance]->SdkSetChannelLabel(channel, label, userflags, position);
 }
 
+cbSdkResult SdkApp::SdkGetChannelType(uint16_t channel, uint8_t * chType)
+{
+	if (m_instInfo == 0)
+		return CBSDKRESULT_CLOSED;
+
+	*chType = m_ChannelType[channel - 1];
+	return CBSDKRESULT_SUCCESS;
+}
+
+CBSDKAPI    cbSdkResult cbSdkGetChannelType(uint32_t nInstance, uint16_t channel, uint8_t *chType)
+{
+	if (channel == 0 || channel > cbMAXCHANS)
+		return CBSDKRESULT_INVALIDCHANNEL;
+	if (chType == NULL)
+		return CBSDKRESULT_NULLPTR;
+	if (nInstance >= cbMAXOPEN)
+		return CBSDKRESULT_INVALIDPARAM;
+	if (g_app[nInstance] == NULL)
+		return CBSDKRESULT_CLOSED;
+	return g_app[nInstance]->SdkGetChannelType(channel, chType);
+}
+
 // Author & Date:   Ehsan Azar     11 March 2011
 /** Retrieve data of a configured trial.
 *
@@ -1817,7 +1836,7 @@ cbSdkResult SdkApp::SdkGetTrialData(uint32_t bActive, cbSdkTrialEvent * trialeve
         if (m_CD == NULL)
             return CBSDKRESULT_ERRCONFIG;
         trialcont->time = prevStartTime;
-        // Take a snashot
+        // Take a snapshot
         memcpy(read_start_index, m_CD->write_start_index, sizeof(read_start_index));
         m_lockTrial.lock();
         memcpy(read_end_index, m_CD->write_index, sizeof(read_end_index));
@@ -1875,90 +1894,105 @@ cbSdkResult SdkApp::SdkGetTrialData(uint32_t bActive, cbSdkTrialEvent * trialeve
 
     if (trialevent)
     {
-        uint32_t read_end_index[cbNUM_ANALOG_CHANS + 2];
-        uint32_t read_start_index[cbNUM_ANALOG_CHANS + 2];
+		// TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
+        uint32_t read_end_index[cbMAXCHANS];
+        uint32_t read_start_index[cbMAXCHANS];
         if (m_ED == NULL)
             return CBSDKRESULT_ERRCONFIG;
-        // Take a snashot
+        
+		// Determine how many samples to copy on this iteration.
+		// We will copy the minimum among (write_index-write_start_index) and
+		// trialevent->num_samples which should correspond to the number of allocated samples.
         memcpy(read_start_index, m_ED->write_start_index, sizeof(read_start_index));
         m_lockTrialEvent.lock();
         memcpy(read_end_index, m_ED->write_index, sizeof(read_end_index));
         m_lockTrialEvent.unlock();
 
-        // copy the data from the "cache" to the allocated memory.
-        for (uint32_t channel = 0; channel < trialevent->count; channel++)
+        // copy the data from the "cache" to the user-allocated memory.
+        for (uint32_t ev_ix = 0; ev_ix < trialevent->count; ev_ix++)
         {
-            uint16_t ch = trialevent->chan[channel]; // channel number
-            if (ch == MAX_CHANS_DIGITAL_IN)
-                ch = cbNUM_ANALOG_CHANS + 1; //index + 1 in cache
-            else if (ch == MAX_CHANS_SERIAL)
-                ch = cbNUM_ANALOG_CHANS + 2; //index + 2 in cache
-            if (ch == 0 || (ch > cbNUM_ANALOG_CHANS + 2))
+            uint16_t ch = trialevent->chan[ev_ix]; // channel number, 1-based
+			if ((m_ChannelType[ch - 1] != cbCHANTYPE_ANAIN) && (m_ChannelType[ch - 1] != cbCHANTYPE_DIGIN) && (m_ChannelType[ch - 1] != cbCHANTYPE_SERIAL))
                 return CBSDKRESULT_INVALIDCHANNEL;
             // Ignore masked channels
-            if (!m_bChannelMask[trialevent->chan[channel] - 1])
+            if (!m_bChannelMask[ch - 1])
             {
-                memset(trialevent->num_samples[channel], 0, sizeof(trialevent->num_samples[channel]));
+                memset(trialevent->num_samples[ev_ix], 0, sizeof(trialevent->num_samples[ev_ix]));
                 continue;
             }
 
             uint32_t read_index = m_ED->write_start_index[ch - 1];
-            int num_samples = read_end_index[ch - 1] - read_index;
+			int num_samples = read_end_index[ch - 1] - read_index;
             if (num_samples < 0)
                 num_samples += m_ED->size;
 
-            uint32_t num_samples_unit[cbMAXUNITS + 1];
+			// We don't know for sure how many samples were allocated,
+			// but this is what the client application was told to allocate.
+			uint32_t num_allocated = 0;
+			for (int unit_ix = 0; unit_ix < cbMAXUNITS; unit_ix++)
+			{
+				num_allocated += trialevent->num_samples[ev_ix][unit_ix];
+			}
+			num_samples = std::min((uint32_t)num_samples, num_allocated);
+
+            uint32_t num_samples_unit[cbMAXUNITS + 1];  // To keep track of how many samples are copied per unit.
             memset(num_samples_unit, 0, sizeof(num_samples_unit));
 
-            for (int i = 0; i < num_samples; ++i)
+            for (int sample_ix = 0; sample_ix < num_samples; ++sample_ix)
             {
-                uint16_t unit = m_ED->units[ch - 1][read_index];
-                if (unit <= cbMAXUNITS + 1)     // remove noise unit
-                {
-                    // Digital or serial data
-                    if (ch > cbNUM_ANALOG_CHANS)
-                    {
-                        if (num_samples_unit[0] < trialevent->num_samples[channel][0])
-                        {
-                            void * dataptr = trialevent->waveforms[channel];
-                            // Null means ignore
-                            if (dataptr)
-                            {
-                                if (m_bTrialDouble)
-                                    *((double *)dataptr + num_samples_unit[0]) = unit;
-                                else
-                                    *((uint16_t *)dataptr + num_samples_unit[0]) = unit;
-                            }
-                        }
-                        unit = 0;
-                    }
-                    // Timestamps
-                    if (num_samples_unit[unit] < trialevent->num_samples[channel][unit])
-                    {
-                        void * dataptr = trialevent->timestamps[channel][unit];
-                        // Null means ignore
-                        if (dataptr)
-                        {
-                            uint32_t ts = m_ED->timestamps[ch - 1][read_index];
-                            // If time wraps or due to reset, time will restart amidst trial
-                            if (!m_bTrialAbsolute && ts >= prevStartTime)
-                                ts -= prevStartTime;
-                            if (m_bTrialDouble)
-                                *((double *)dataptr + num_samples_unit[unit]) = cbSdk_SECONDS_PER_TICK * ts;
-                            else
-                                *((uint32_t *)dataptr + num_samples_unit[unit]) = ts;
-                        }
-                        num_samples_unit[unit]++;
-                    } 
-                }
+                uint16_t unit = m_ED->units[ch - 1][read_index];  // pktType for anain, or the first data value for dig/serial.
 
-                read_index++;
-                if (read_index >= m_ED->size)
-                    read_index = 0;
+				// For digital or serial data, 'unit' holds data, and is not indicating the unit number.
+				// So here we copy the data to trialevent->waveforms, then set unit to 0.
+				if ((m_ChannelType[ch - 1] == cbCHANTYPE_DIGIN) || (m_ChannelType[ch - 1] == cbCHANTYPE_SERIAL))
+				{
+					if (num_samples_unit[0] < trialevent->num_samples[ev_ix][0])
+					{
+						void * dataptr = trialevent->waveforms[ev_ix];
+						// Null means ignore
+						if (dataptr)
+						{
+							if (m_bTrialDouble)
+								*((double *)dataptr + num_samples_unit[0]) = unit;
+							else
+								*((uint16_t *)dataptr + num_samples_unit[0]) = unit;
+						}
+					}
+					unit = 0;
+				}
+
+				// Timestamps
+				if (unit <= cbMAXUNITS + 1)     // remove noise unit. why?
+				{
+					if (num_samples_unit[unit] < trialevent->num_samples[ev_ix][unit])
+					{
+						void * dataptr = trialevent->timestamps[ev_ix][unit];
+						// Null means ignore
+						if (dataptr)
+						{
+							uint32_t ts = m_ED->timestamps[ch - 1][read_index];
+							// If time wraps or due to reset, time will restart amidst trial
+							if (!m_bTrialAbsolute && ts >= prevStartTime)
+								ts -= prevStartTime;
+							if (m_bTrialDouble)
+								*((double *)dataptr + num_samples_unit[unit]) = cbSdk_SECONDS_PER_TICK * ts;
+							else
+								*((uint32_t *)dataptr + num_samples_unit[unit]) = ts;
+						}
+						num_samples_unit[unit]++;
+						
+						// Increment the read index.
+						read_index++;
+						if (read_index >= m_ED->size)
+							read_index = 0;
+					} 
+                }
             }
-            // retrieved number of samples
-            memcpy(trialevent->num_samples[channel], num_samples_unit, sizeof(num_samples_unit));
-            // Flush the buffer and start a new 'trial'...
+            
+			// retrieved number of samples
+            memcpy(trialevent->num_samples[ev_ix], num_samples_unit, sizeof(num_samples_unit));
+            
+			// Flush the buffer and start a new 'trial'...
             if (bActive)
                 read_start_index[ch - 1] = read_index;
         }
@@ -2197,13 +2231,14 @@ cbSdkResult SdkApp::SdkInitTrialData(uint32_t bActive, cbSdkTrialEvent * trialev
             m_bPacketsEvent = TRUE;
             m_lockGetPacketsEvent.unlock();
 
-            uint32_t read_end_index[cbNUM_ANALOG_CHANS + 2];
+			// TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
+            uint32_t read_end_index[cbMAXCHANS];
             // Take a snapshot of the current write pointer
             m_lockTrialEvent.lock();
             memcpy(read_end_index, m_ED->write_index, sizeof(read_end_index));
             m_lockTrialEvent.unlock();
             int count = 0;
-            for (uint32_t channel = 0; channel < cbNUM_ANALOG_CHANS + 2; channel++)
+            for (uint32_t channel = 0; channel < cbMAXCHANS; channel++)
             {
                 uint32_t i = m_ED->write_start_index[channel];
                 int num_samples = read_end_index[channel] - i;
@@ -2211,17 +2246,14 @@ cbSdkResult SdkApp::SdkInitTrialData(uint32_t bActive, cbSdkTrialEvent * trialev
                     num_samples += m_ED->size;
                 if (num_samples == 0)
                     continue;
-                uint16_t ch = channel + 1; // Actual channel number
-                if (ch > cbNUM_ANALOG_CHANS)
-                    ch += cbNUM_ANALOGOUT_CHANS;
-                if (!m_bChannelMask[ch - 1])
+                if (!m_bChannelMask[channel])
                     continue;
-                trialevent->chan[count] = ch;
+                trialevent->chan[count] = channel + 1;
                 // Count sample numbers for each unit seperately
                 while (i != read_end_index[channel])
                 {
                     uint16_t unit = m_ED->units[channel][i];
-                    if (unit > cbMAXUNITS || channel >= cbNUM_ANALOG_CHANS)
+                    if ((unit > cbMAXUNITS) || (m_ChannelType[channel] != cbCHANTYPE_ANAIN))
                         unit = 0;
                     trialevent->num_samples[count][unit]++;
                     if (++i >= m_ED->size)
@@ -3963,6 +3995,7 @@ void SdkApp::ProcessIncomingPacket(const cbPKT_GENERIC * const pPkt)
 
     // This callback type needs to be bound only once
     LateBindCallback(CBSDKCALLBACK_ALL);
+	bool b_checkEvent = false;
 
     // check for configuration class packets
     if (pPkt->chid & cbPKTCHAN_CONFIGURATION)
@@ -4095,46 +4128,49 @@ void SdkApp::ProcessIncomingPacket(const cbPKT_GENERIC * const pPkt)
                 m_pLateCallback[CBSDKCALLBACK_CONTINUOUS](m_nInstance, cbSdkPkt_CONTINUOUS, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_CONTINUOUS]);
         }
     }
-    // check for channel event packets cerebus channels 1-272
-    else if (pPkt->chid < cbNUM_ANALOG_CHANS + 1)   // channels are 1 based
-    {
-        if (pPkt->chid > 0 && m_bChannelMask[pPkt->chid - 1])
-        {
-            if (m_pLateCallback[CBSDKCALLBACK_ALL])
-                m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_SPIKE, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
-            // Late bind before usage
-            LateBindCallback(CBSDKCALLBACK_SPIKE);
-            if (m_pLateCallback[CBSDKCALLBACK_SPIKE])
-                m_pLateCallback[CBSDKCALLBACK_SPIKE](m_nInstance, cbSdkPkt_SPIKE, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_SPIKE]);
-        }
-    }
-    // catch digital input port events and save them as NSAS experiment event packets
-    else if (pPkt->chid == MAX_CHANS_DIGITAL_IN)
-    {
-        if (m_bChannelMask[pPkt->chid - 1])
-        {
-            if (m_pLateCallback[CBSDKCALLBACK_ALL])
-                m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_DIGITAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
-            // Late bind before usage
-            LateBindCallback(CBSDKCALLBACK_DIGITAL);
-            if (m_pLateCallback[CBSDKCALLBACK_DIGITAL])
-                m_pLateCallback[CBSDKCALLBACK_DIGITAL](m_nInstance, cbSdkPkt_DIGITAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_DIGITAL]);
-        }
-    }
-    // catch serial input port events and save them as NSAS experiment event packets
-    else if (pPkt->chid == MAX_CHANS_SERIAL)
-    {
-        if (m_bChannelMask[pPkt->chid - 1])
-        {
-            if (m_pLateCallback[CBSDKCALLBACK_ALL])
-                m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_SERIAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
-            // Late bind before usage
-            LateBindCallback(CBSDKCALLBACK_SERIAL);
-            if (m_pLateCallback[CBSDKCALLBACK_SERIAL])
-                m_pLateCallback[CBSDKCALLBACK_SERIAL](m_nInstance, cbSdkPkt_SERIAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_SERIAL]);
-        }
-    }
-
+	// check for channel event packets cerebus channels 1-272
+	else if (m_ChannelType[pPkt->chid-1] == cbCHANTYPE_ANAIN) // channels are 1-based, m_ChannelType is 0-based.
+	{
+		if (m_bChannelMask[pPkt->chid - 1])
+		{
+			b_checkEvent = true;
+			if (m_pLateCallback[CBSDKCALLBACK_ALL])
+				m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_SPIKE, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
+			// Late bind before usage
+			LateBindCallback(CBSDKCALLBACK_SPIKE);
+			if (m_pLateCallback[CBSDKCALLBACK_SPIKE])
+				m_pLateCallback[CBSDKCALLBACK_SPIKE](m_nInstance, cbSdkPkt_SPIKE, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_SPIKE]);
+		}
+	}
+	// catch digital input port events and save them as NSAS experiment event packets
+	else if (m_ChannelType[pPkt->chid - 1] == cbCHANTYPE_DIGIN)
+	{
+		if (m_bChannelMask[pPkt->chid - 1])
+		{
+			b_checkEvent = true;
+			if (m_pLateCallback[CBSDKCALLBACK_ALL])
+				m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_DIGITAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
+			// Late bind before usage
+			LateBindCallback(CBSDKCALLBACK_DIGITAL);
+			if (m_pLateCallback[CBSDKCALLBACK_DIGITAL])
+				m_pLateCallback[CBSDKCALLBACK_DIGITAL](m_nInstance, cbSdkPkt_DIGITAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_DIGITAL]);
+		}
+	}
+	// catch serial input port events and save them as NSAS experiment event packets
+	else if (m_ChannelType[pPkt->chid - 1] == cbCHANTYPE_SERIAL)
+	{
+		if (m_bChannelMask[pPkt->chid - 1])
+		{
+			b_checkEvent = true;
+			if (m_pLateCallback[CBSDKCALLBACK_ALL])
+				m_pLateCallback[CBSDKCALLBACK_ALL](m_nInstance, cbSdkPkt_SERIAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_ALL]);
+			// Late bind before usage
+			LateBindCallback(CBSDKCALLBACK_SERIAL);
+			if (m_pLateCallback[CBSDKCALLBACK_SERIAL])
+				m_pLateCallback[CBSDKCALLBACK_SERIAL](m_nInstance, cbSdkPkt_SERIAL, pPkt, m_pLateCallbackParams[CBSDKCALLBACK_SERIAL]);
+		}
+	}
+    
     // save the timestamp to overcome the case where the reset button is pressed
     // (or recording started) which resets the timestamp to 0, but Central doesn't
     // reset it's timer to 0 for cbGetSystemClockTime
@@ -4145,7 +4181,7 @@ void SdkApp::ProcessIncomingPacket(const cbPKT_GENERIC * const pPkt)
         OnPktGroup(reinterpret_cast<const cbPKT_GROUP*>(pPkt));
 
     // and only look at event data packets
-    if ( pPkt->chid == MAX_CHANS_DIGITAL_IN || pPkt->chid == MAX_CHANS_SERIAL || (pPkt->chid > 0 && pPkt->chid <= cbNUM_ANALOG_CHANS) )
+    if (b_checkEvent)
         OnPktEvent(pPkt);
 }
 

--- a/cbmex/cbsdk.h
+++ b/cbmex/cbsdk.h
@@ -261,7 +261,7 @@ typedef void (* cbSdkCallback)(uint32_t nInstance, const cbSdkPktType type, cons
 /// Trial spike events
 typedef struct _cbSdkTrialEvent
 {
-	// TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
+    // TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
     uint16_t count; ///< Number of valid channels in this trial (up to cbNUM_ANALOG_CHANS+2)
     uint16_t chan[cbMAXCHANS]; ///< channel numbers (1-based)
     uint32_t num_samples[cbMAXCHANS][cbMAXUNITS + 1]; ///< number of samples
@@ -277,9 +277,9 @@ typedef struct _cbSdkConnection
         nInPort = cbNET_UDP_PORT_BCAST;
         nOutPort = cbNET_UDP_PORT_CNT;
         #ifdef __APPLE__
-			nRecBufSize = (6 * 1024 * 1024); // Despite setting kern.ipc.maxsockbuf=8388608, 8MB is still too much.
+            nRecBufSize = (6 * 1024 * 1024); // Despite setting kern.ipc.maxsockbuf=8388608, 8MB is still too much.
         #else
-			nRecBufSize = (8 * 1024 * 1024); // 8MB default needed for best performance
+            nRecBufSize = (8 * 1024 * 1024); // 8MB default needed for best performance
         #endif
         szInIP = "";
         szOutIP = "";
@@ -401,7 +401,7 @@ typedef enum _cbSdkExtCmdType
     cbSdkExtCmd_RPC = 0,    // RPC command
     cbSdkExtCmd_UPLOAD,     // Upload the file
     cbSdkExtCmd_TERMINATE,  // Signal last RPC command to terminate
-    cbSdkExtCmd_INPUT,		// Input to RPC command
+    cbSdkExtCmd_INPUT,      // Input to RPC command
     cbSdkExtCmd_END_PLUGIN, // Signal to end plugin
     cbSdkExtCmd_NSP_REBOOT, // Restart the NSP
 } cbSdkExtCmdType;
@@ -467,7 +467,7 @@ CBSDKAPI    cbSdkResult cbSdkGetChannelLabel(uint32_t nInstance, uint16_t channe
 CBSDKAPI    cbSdkResult cbSdkSetChannelLabel(uint32_t nInstance, uint16_t channel, const char * label, uint32_t userflags, int32_t * position); // Set channel label
 
 /*! Get channel type */
-CBSDKAPI	cbSdkResult cbSdkGetChannelType(uint32_t nInstance, uint16_t channel, uint8_t* ch_type);
+CBSDKAPI    cbSdkResult cbSdkGetChannelType(uint32_t nInstance, uint16_t channel, uint8_t* ch_type);
 
 /*! Retrieve data of a trial (NULL means ignore), user should allocate enough buffers beforehand, and trial should not be closed during this call */
 CBSDKAPI    cbSdkResult cbSdkGetTrialData(uint32_t nInstance,

--- a/cbmex/cbsdk.h
+++ b/cbmex/cbsdk.h
@@ -261,11 +261,12 @@ typedef void (* cbSdkCallback)(uint32_t nInstance, const cbSdkPktType type, cons
 /// Trial spike events
 typedef struct _cbSdkTrialEvent
 {
+	// TODO: Go back to using cbNUM_ANALOG_CHANS + 2 after we have m_ChIdxInType
     uint16_t count; ///< Number of valid channels in this trial (up to cbNUM_ANALOG_CHANS+2)
-    uint16_t chan[cbNUM_ANALOG_CHANS + 2]; ///< channel numbers (1-based)
-    uint32_t num_samples[cbNUM_ANALOG_CHANS + 2][cbMAXUNITS + 1]; ///< number of samples
-    void * timestamps[cbNUM_ANALOG_CHANS + 2][cbMAXUNITS + 1];   ///< Buffer to hold time stamps
-    void * waveforms[cbNUM_ANALOG_CHANS + 2]; ///< Buffer to hold waveforms or digital values
+    uint16_t chan[cbMAXCHANS]; ///< channel numbers (1-based)
+    uint32_t num_samples[cbMAXCHANS][cbMAXUNITS + 1]; ///< number of samples
+    void * timestamps[cbMAXCHANS][cbMAXUNITS + 1];   ///< Buffer to hold time stamps
+    void * waveforms[cbMAXCHANS]; ///< Buffer to hold waveforms or digital values
 } cbSdkTrialEvent;
 
 /// Connection information
@@ -464,6 +465,9 @@ CBSDKAPI    cbSdkResult cbSdkUnsetTrialConfig(uint32_t nInstance, cbSdkTrialType
 CBSDKAPI    cbSdkResult cbSdkGetChannelLabel(uint32_t nInstance, uint16_t channel, uint32_t * bValid, char * label = NULL, uint32_t * userflags = NULL, int32_t * position = NULL); // Get channel label
 /*! Set channel label */
 CBSDKAPI    cbSdkResult cbSdkSetChannelLabel(uint32_t nInstance, uint16_t channel, const char * label, uint32_t userflags, int32_t * position); // Set channel label
+
+/*! Get channel type */
+CBSDKAPI	cbSdkResult cbSdkGetChannelType(uint32_t nInstance, uint16_t channel, uint8_t* ch_type);
 
 /*! Retrieve data of a trial (NULL means ignore), user should allocate enough buffers beforehand, and trial should not be closed during this call */
 CBSDKAPI    cbSdkResult cbSdkGetTrialData(uint32_t nInstance,

--- a/cbmex/test_io.cpp
+++ b/cbmex/test_io.cpp
@@ -29,103 +29,103 @@
 #define INST 0
 
 typedef struct _cbsdk_config {
-	uint32_t nInstance;
-	uint32_t bActive;
-	uint16_t begchan;
-	uint32_t begmask;
-	uint32_t begval;
-	uint16_t endchan;
-	uint32_t endmask;
-	uint32_t endval;
-	bool bDouble;
-	uint32_t uWaveforms;
-	uint32_t uConts;
-	uint32_t uEvents;
-	uint32_t uComments;
-	uint32_t uTrackings;
-	bool bAbsolute;
+    uint32_t nInstance;
+    uint32_t bActive;
+    uint16_t begchan;
+    uint32_t begmask;
+    uint32_t begval;
+    uint16_t endchan;
+    uint32_t endmask;
+    uint32_t endval;
+    bool bDouble;
+    uint32_t uWaveforms;
+    uint32_t uConts;
+    uint32_t uEvents;
+    uint32_t uComments;
+    uint32_t uTrackings;
+    bool bAbsolute;
 } cbsdk_config;
 
 void handleResult(cbSdkResult res)
 {
-	switch (res)
-	{
-	case CBSDKRESULT_SUCCESS:
-		break;
-	case CBSDKRESULT_NOTIMPLEMENTED:
-		printf("Not implemented\n");
-		break;
-	case CBSDKRESULT_INVALIDPARAM:
-		printf("Invalid parameter\n");
-		break;
-	case CBSDKRESULT_WARNOPEN:
-		printf("Real-time interface already initialized\n");
-	case CBSDKRESULT_WARNCLOSED:
-		printf("Real-time interface already closed\n");
-		break;
-	case CBSDKRESULT_ERROPENCENTRAL:
-		printf("Unable to open library for Central interface\n");
-		break;
-	case CBSDKRESULT_ERROPENUDP:
-		printf("Unable to open library for UDP interface\n");
-		break;
-	case CBSDKRESULT_ERROPENUDPPORT:
-		printf("Unable to open UDP interface\n");
-		break;
-	case CBSDKRESULT_OPTERRUDP:
-		printf("Unable to set UDP interface option\n");
-		break;
-	case CBSDKRESULT_MEMERRUDP:
-		printf("Unable to assign UDP interface memory\n"
-			" Consider using sysctl -w net.core.rmem_max=8388608\n"
-			" or sysctl -w kern.ipc.maxsockbuf=8388608\n");
-		break;
-	case CBSDKRESULT_INVALIDINST:
-		printf("Invalid UDP interface\n");
-		break;
-	case CBSDKRESULT_ERRMEMORYTRIAL:
-		printf("Unable to allocate RAM for trial cache data\n");
-		break;
-	case CBSDKRESULT_ERROPENUDPTHREAD:
-		printf("Unable to Create UDP thread\n");
-		break;
-	case CBSDKRESULT_ERROPENCENTRALTHREAD:
-		printf("Unable to start Cerebus real-time data thread\n");
-		break;
-	case CBSDKRESULT_ERRINIT:
-		printf("Library initialization error\n");
-		break;
-	case CBSDKRESULT_ERRMEMORY:
-		printf("Library memory allocation error\n");
-		break;
-	case CBSDKRESULT_TIMEOUT:
-		printf("Connection timeout error\n");
-		break;
-	case CBSDKRESULT_ERROFFLINE:
-		printf("Instrument is offline\n");
-		break;
-	default:
-		printf("Unexpected error\n");
-		break;
-	}
+    switch (res)
+    {
+    case CBSDKRESULT_SUCCESS:
+        break;
+    case CBSDKRESULT_NOTIMPLEMENTED:
+        printf("Not implemented\n");
+        break;
+    case CBSDKRESULT_INVALIDPARAM:
+        printf("Invalid parameter\n");
+        break;
+    case CBSDKRESULT_WARNOPEN:
+        printf("Real-time interface already initialized\n");
+    case CBSDKRESULT_WARNCLOSED:
+        printf("Real-time interface already closed\n");
+        break;
+    case CBSDKRESULT_ERROPENCENTRAL:
+        printf("Unable to open library for Central interface\n");
+        break;
+    case CBSDKRESULT_ERROPENUDP:
+        printf("Unable to open library for UDP interface\n");
+        break;
+    case CBSDKRESULT_ERROPENUDPPORT:
+        printf("Unable to open UDP interface\n");
+        break;
+    case CBSDKRESULT_OPTERRUDP:
+        printf("Unable to set UDP interface option\n");
+        break;
+    case CBSDKRESULT_MEMERRUDP:
+        printf("Unable to assign UDP interface memory\n"
+            " Consider using sysctl -w net.core.rmem_max=8388608\n"
+            " or sysctl -w kern.ipc.maxsockbuf=8388608\n");
+        break;
+    case CBSDKRESULT_INVALIDINST:
+        printf("Invalid UDP interface\n");
+        break;
+    case CBSDKRESULT_ERRMEMORYTRIAL:
+        printf("Unable to allocate RAM for trial cache data\n");
+        break;
+    case CBSDKRESULT_ERROPENUDPTHREAD:
+        printf("Unable to Create UDP thread\n");
+        break;
+    case CBSDKRESULT_ERROPENCENTRALTHREAD:
+        printf("Unable to start Cerebus real-time data thread\n");
+        break;
+    case CBSDKRESULT_ERRINIT:
+        printf("Library initialization error\n");
+        break;
+    case CBSDKRESULT_ERRMEMORY:
+        printf("Library memory allocation error\n");
+        break;
+    case CBSDKRESULT_TIMEOUT:
+        printf("Connection timeout error\n");
+        break;
+    case CBSDKRESULT_ERROFFLINE:
+        printf("Instrument is offline\n");
+        break;
+    default:
+        printf("Unexpected error\n");
+        break;
+    }
 }
 
 
 cbSdkVersion testGetVersion(void)
 {
-	// Library version can be read even before library open (return value is a warning)
-	//  actual NSP version however needs library to be open
-	cbSdkVersion ver;
-	cbSdkResult res = cbSdkGetVersion(INST, &ver);
-	if (res != CBSDKRESULT_SUCCESS)
-	{
-		printf("Unable to determine instrument version\n");
-	}
-	else {
-		printf("Initializing Cerebus real-time interface %d.%02d.%02d.%02d (protocol cb%d.%02d)...\n", ver.major, ver.minor, ver.release, ver.beta, ver.majorp, ver.minorp);
-	}
-	handleResult(res);
-	return ver;
+    // Library version can be read even before library open (return value is a warning)
+    //  actual NSP version however needs library to be open
+    cbSdkVersion ver;
+    cbSdkResult res = cbSdkGetVersion(INST, &ver);
+    if (res != CBSDKRESULT_SUCCESS)
+    {
+        printf("Unable to determine instrument version\n");
+    }
+    else {
+        printf("Initializing Cerebus real-time interface %d.%02d.%02d.%02d (protocol cb%d.%02d)...\n", ver.major, ver.minor, ver.release, ver.beta, ver.majorp, ver.minorp);
+    }
+    handleResult(res);
+    return ver;
 }
 
 // Author & Date:   Ehsan Azar    24 Oct 2012
@@ -135,23 +135,23 @@ cbSdkResult testOpen(void)
     // Try to get the version. Should be a warning because we are not yet open.
     cbSdkVersion ver = testGetVersion();
 
-	// Open the device using default connection type.
-	cbSdkConnectionType conType = CBSDKCONNECTION_DEFAULT;
-	cbSdkResult res = cbSdkOpen(INST, conType);
-	if (res != CBSDKRESULT_SUCCESS)
-		printf("Unable to open instrument connection.\n");
-	handleResult(res);
+    // Open the device using default connection type.
+    cbSdkConnectionType conType = CBSDKCONNECTION_DEFAULT;
+    cbSdkResult res = cbSdkOpen(INST, conType);
+    if (res != CBSDKRESULT_SUCCESS)
+        printf("Unable to open instrument connection.\n");
+    handleResult(res);
 
-	cbSdkInstrumentType instType;
+    cbSdkInstrumentType instType;
     if (res >= 0)
     {
         // Return the actual opened connection
         res = cbSdkGetType(INST, &conType, &instType);
-		if (res != CBSDKRESULT_SUCCESS)
-			printf("Unable to determine connection type\n");
-		handleResult(res);
-		// if (instType == CBSDKINSTRUMENT_NPLAY || instType == CBSDKINSTRUMENT_REMOTENPLAY)
-		//  	printf("Unable to open UDP interface to nPlay\n");
+        if (res != CBSDKRESULT_SUCCESS)
+            printf("Unable to determine connection type\n");
+        handleResult(res);
+        // if (instType == CBSDKINSTRUMENT_NPLAY || instType == CBSDKINSTRUMENT_REMOTENPLAY)
+        //  	printf("Unable to open UDP interface to nPlay\n");
         
 
         if (conType < 0 || conType > CBSDKCONNECTION_CLOSED)
@@ -162,10 +162,10 @@ cbSdkResult testOpen(void)
         char strConnection[CBSDKCONNECTION_COUNT + 1][8] = {"Default", "Central", "Udp", "Closed", "Unknown"};
         char strInstrument[CBSDKINSTRUMENT_COUNT + 1][13] = {"NSP", "nPlay", "Local NSP", "Remote nPlay", "Unknown"};
 
-		// Now that we are open, get the version again.
-		ver = testGetVersion();
+        // Now that we are open, get the version again.
+        ver = testGetVersion();
 
-		// Summary results.
+        // Summary results.
         printf("%s real-time interface to %s (%d.%02d.%02d.%02d) successfully initialized\n", strConnection[conType], strInstrument[instType], ver.nspmajor, ver.nspminor, ver.nsprelease, ver.nspbeta);
     }
 
@@ -175,25 +175,25 @@ cbSdkResult testOpen(void)
 
 void testGetConfig(void)
 {
-	uint32_t proc = 1;
-	uint32_t nChansInGroup;
-	uint16_t pGroupList[cbNUM_ANALOG_CHANS];
-	for (uint32_t group_ix = 1; group_ix < 7; group_ix++)
-	{
-		cbSdkResult res = cbSdkGetSampleGroupList(INST, proc, group_ix, &nChansInGroup, pGroupList);
-		if (res == CBSDKRESULT_SUCCESS)
-		{
-			printf("In sampling group %d, found %d channels.\n", group_ix, nChansInGroup);
-		}
-		handleResult(res);
-	}
+    uint32_t proc = 1;
+    uint32_t nChansInGroup;
+    uint16_t pGroupList[cbNUM_ANALOG_CHANS];
+    for (uint32_t group_ix = 1; group_ix < 7; group_ix++)
+    {
+        cbSdkResult res = cbSdkGetSampleGroupList(INST, proc, group_ix, &nChansInGroup, pGroupList);
+        if (res == CBSDKRESULT_SUCCESS)
+        {
+            printf("In sampling group %d, found %d channels.\n", group_ix, nChansInGroup);
+        }
+        handleResult(res);
+    }
 }
 
 void testGetTrialConfig(cbsdk_config& cfg)
 {
-	cbSdkResult res = cbSdkGetTrialConfig(INST, &cfg.bActive, &cfg.begchan, &cfg.begmask, &cfg.begval,
-		&cfg.endchan, &cfg.endmask, &cfg.endval, &cfg.bDouble,
-		&cfg.uWaveforms, &cfg.uConts, &cfg.uEvents, &cfg.uComments, &cfg.uTrackings, &cfg.bAbsolute);
+    cbSdkResult res = cbSdkGetTrialConfig(INST, &cfg.bActive, &cfg.begchan, &cfg.begmask, &cfg.begval,
+        &cfg.endchan, &cfg.endmask, &cfg.endval, &cfg.bDouble,
+        &cfg.uWaveforms, &cfg.uConts, &cfg.uEvents, &cfg.uComments, &cfg.uTrackings, &cfg.bAbsolute);
 }
 
 // Author & Date:   Ehsan Azar    25 Oct 2012
@@ -201,15 +201,15 @@ void testGetTrialConfig(cbsdk_config& cfg)
 cbSdkResult testClose(void)
 {
     cbSdkResult res = cbSdkClose(INST);
-	if (res == CBSDKRESULT_SUCCESS)
-	{
-		printf("Interface closed successfully\n");
-	}
-	else
-	{
-		printf("Unable to close interface.\n");
-		handleResult(res);
-	}
+    if (res == CBSDKRESULT_SUCCESS)
+    {
+        printf("Interface closed successfully\n");
+    }
+    else
+    {
+        printf("Unable to close interface.\n");
+        handleResult(res);
+    }
     return res;
 }
 
@@ -217,192 +217,192 @@ cbSdkResult testClose(void)
 // The test suit main entry
 int main(int argc, char *argv[])
 {
-	// Parse command line arguments.
-	bool bCont = false;
-	bool bEv = false;
-	bool bComm = false;
-	uint32_t runtime = 30000;
-	size_t optind;
-	for (optind = 1; optind < argc && argv[optind][0] == '-'; optind++)
-	{
-		switch (argv[optind][1]) {
-		case 'c': bCont = true; break;
-		case 'e': bEv = true; break;
-		case 'r': runtime = 30000 * (argv[optind][2] - '0');
-		}
-	}
+    // Parse command line arguments.
+    bool bCont = false;
+    bool bEv = false;
+    bool bComm = false;
+    uint32_t runtime = 30000;
+    size_t optind;
+    for (optind = 1; optind < argc && argv[optind][0] == '-'; optind++)
+    {
+        switch (argv[optind][1]) {
+        case 'c': bCont = true; break;
+        case 'e': bEv = true; break;
+        case 'r': runtime = 30000 * (argv[optind][2] - '0');
+        }
+    }
 
     cbSdkResult res = testOpen();
     if (res < 0)
         printf("testOpen failed (%d)!\n", res);
     else
         printf("testOpen succeeded\n");
-	
-	testGetConfig();
+    
+    testGetConfig();
 
-	cbsdk_config cfg;
-	testGetTrialConfig(cfg);
-	cfg.bActive = 1;
+    cbsdk_config cfg;
+    testGetTrialConfig(cfg);
+    cfg.bActive = 1;
 
-	cfg.uConts = bCont ? cbSdk_CONTINUOUS_DATA_SAMPLES : 0;
-	cfg.uEvents = bEv ? cbSdk_EVENT_DATA_SAMPLES : 0;
-	res = cbSdkSetTrialConfig(INST, cfg.bActive, cfg.begchan, cfg.begmask, cfg.begval, cfg.endchan, cfg.endmask, cfg.endval,
-		cfg.bDouble, cfg.uWaveforms, cfg.uConts, cfg.uEvents, cfg.uComments, cfg.uTrackings, cfg.bAbsolute);
+    cfg.uConts = bCont ? cbSdk_CONTINUOUS_DATA_SAMPLES : 0;
+    cfg.uEvents = bEv ? cbSdk_EVENT_DATA_SAMPLES : 0;
+    res = cbSdkSetTrialConfig(INST, cfg.bActive, cfg.begchan, cfg.begmask, cfg.begval, cfg.endchan, cfg.endmask, cfg.endval,
+        cfg.bDouble, cfg.uWaveforms, cfg.uConts, cfg.uEvents, cfg.uComments, cfg.uTrackings, cfg.bAbsolute);
 
-	uint32_t start_time;
-	uint32_t elapsed_time = 0;
-	res = cbSdkGetTime(INST, &start_time);
-	char kb_ch = '1';
-	while ((kb_ch != 27) && ((runtime == 0) || (elapsed_time < runtime)))
-	{
-		res = cbSdkGetTime(INST, &elapsed_time);
-		elapsed_time -= start_time;
+    uint32_t start_time;
+    uint32_t elapsed_time = 0;
+    res = cbSdkGetTime(INST, &start_time);
+    char kb_ch = '1';
+    while ((kb_ch != 27) && ((runtime == 0) || (elapsed_time < runtime)))
+    {
+        res = cbSdkGetTime(INST, &elapsed_time);
+        elapsed_time -= start_time;
 
-		// cbSdkInitTrialData to determine how many samples are available
-		cbSdkTrialEvent* ptrialevent = new cbSdkTrialEvent;
-		if (!bEv) {
-			delete ptrialevent;
-			ptrialevent = nullptr;
-		}
-		cbSdkTrialCont* ptrialcont = new cbSdkTrialCont;
-		if (!bCont) {
-			delete ptrialcont;
-			ptrialcont = nullptr;
-		}
-		cbSdkTrialComment* ptrialcomment = new cbSdkTrialComment;
-		if (!bComm) {
-			delete ptrialcomment;
-			ptrialcomment = nullptr;
-		}
-		res = cbSdkInitTrialData(INST, 0, ptrialevent, ptrialcont, ptrialcomment, 0);
+        // cbSdkInitTrialData to determine how many samples are available
+        cbSdkTrialEvent* ptrialevent = new cbSdkTrialEvent;
+        if (!bEv) {
+            delete ptrialevent;
+            ptrialevent = nullptr;
+        }
+        cbSdkTrialCont* ptrialcont = new cbSdkTrialCont;
+        if (!bCont) {
+            delete ptrialcont;
+            ptrialcont = nullptr;
+        }
+        cbSdkTrialComment* ptrialcomment = new cbSdkTrialComment;
+        if (!bComm) {
+            delete ptrialcomment;
+            ptrialcomment = nullptr;
+        }
+        res = cbSdkInitTrialData(INST, 0, ptrialevent, ptrialcont, ptrialcomment, 0);
 
-		// allocate memory
-		if (ptrialevent && (ptrialevent->count > 0))
-		{
-			for (size_t ev_ix = 0; ev_ix < ptrialevent->count; ev_ix++)
-			{
-				uint16_t chan_id = ptrialevent->chan[ev_ix];  // 1-based
+        // allocate memory
+        if (ptrialevent && (ptrialevent->count > 0))
+        {
+            for (size_t ev_ix = 0; ev_ix < ptrialevent->count; ev_ix++)
+            {
+                uint16_t chan_id = ptrialevent->chan[ev_ix];  // 1-based
 
-				// Every event channel, regardless of type (spike, digital, serial), gets an array of timestamps.
-				for (size_t un_ix = 0; un_ix < cbMAXUNITS + 1; un_ix++)
-				{
-					uint32_t n_samples = ptrialevent->num_samples[ev_ix][un_ix];
-					if (n_samples)
-					{
-						// alloc num_samples uint32_t
-						ptrialevent->timestamps[ev_ix][un_ix] = malloc(n_samples * sizeof(uint32_t));
-					}
-					else {
-						ptrialevent->timestamps[ev_ix][un_ix] = NULL;
-					}
-				}
+                // Every event channel, regardless of type (spike, digital, serial), gets an array of timestamps.
+                for (size_t un_ix = 0; un_ix < cbMAXUNITS + 1; un_ix++)
+                {
+                    uint32_t n_samples = ptrialevent->num_samples[ev_ix][un_ix];
+                    if (n_samples)
+                    {
+                        // alloc num_samples uint32_t
+                        ptrialevent->timestamps[ev_ix][un_ix] = malloc(n_samples * sizeof(uint32_t));
+                    }
+                    else {
+                        ptrialevent->timestamps[ev_ix][un_ix] = NULL;
+                    }
+                }
 
-				uint8_t chanType;
-				cbSdkGetChannelType(INST, chan_id, &chanType);
-				if ((chanType == cbCHANTYPE_DIGIN) || (chanType == cbCHANTYPE_SERIAL))
-				{
-					// alloc waveform data
-					uint32_t n_samples = ptrialevent->num_samples[ev_ix][0];
-					ptrialevent->waveforms[ev_ix] = malloc(n_samples * sizeof(uint16_t));
-					// TODO: If double then allocate sizeof(double)
-				}
-			}
-		}
+                uint8_t chanType;
+                cbSdkGetChannelType(INST, chan_id, &chanType);
+                if ((chanType == cbCHANTYPE_DIGIN) || (chanType == cbCHANTYPE_SERIAL))
+                {
+                    // alloc waveform data
+                    uint32_t n_samples = ptrialevent->num_samples[ev_ix][0];
+                    ptrialevent->waveforms[ev_ix] = malloc(n_samples * sizeof(uint16_t));
+                    // TODO: If double then allocate sizeof(double)
+                }
+            }
+        }
 
-		if (ptrialcont && (ptrialcont->count > 0))
-		{
-			// TODO: Allocate continuous data
-		}
-		
-		// cbSdkGetTrialData to fetch the data
-		res = cbSdkGetTrialData(INST, cfg.bActive, ptrialevent, ptrialcont, ptrialcomment, 0);
+        if (ptrialcont && (ptrialcont->count > 0))
+        {
+            // TODO: Allocate continuous data
+        }
+        
+        // cbSdkGetTrialData to fetch the data
+        res = cbSdkGetTrialData(INST, cfg.bActive, ptrialevent, ptrialcont, ptrialcomment, 0);
 
-		// Print something to do with the data.
-		if (ptrialevent && (ptrialevent->count > 0))
-		{
-			for (size_t ev_ix = 0; ev_ix < ptrialevent->count; ev_ix++)
-			{
-				for (size_t un_ix = 0; un_ix < cbMAXUNITS + 1; un_ix++)
-				{
-					if (ptrialevent->num_samples[ev_ix][un_ix])
-					{
-						uint32_t* ts = (uint32_t *)ptrialevent->timestamps[ev_ix][un_ix];
-						// printf(" %" PRIu32, *ts);
-					}
-				}
-				// printf("\n");
-				
-				uint16_t chan_id = ptrialevent->chan[ev_ix];
-				uint8_t chanType;
-				cbSdkGetChannelType(INST, chan_id, &chanType);
-				if ((chanType == cbCHANTYPE_DIGIN) || (chanType == cbCHANTYPE_SERIAL))
-				{
-					uint32_t n_samples = ptrialevent->num_samples[ev_ix][0];
-					if (n_samples > 0)
-					{
-						uint32_t* ts = (uint32_t *)ptrialevent->timestamps[ev_ix][0];
-						printf("%" PRIu32 ":", *ts);
-					}
-					uint16_t* wf = (uint16_t*)ptrialevent->waveforms[ev_ix];
-					for (uint32_t sample_ix = 0; sample_ix < n_samples; sample_ix++)
-					{
-						printf(" %" PRIu16, wf[sample_ix]);
-					}
-					if (n_samples > 0) printf("\n");
-				}
-			}
-		}
+        // Print something to do with the data.
+        if (ptrialevent && (ptrialevent->count > 0))
+        {
+            for (size_t ev_ix = 0; ev_ix < ptrialevent->count; ev_ix++)
+            {
+                for (size_t un_ix = 0; un_ix < cbMAXUNITS + 1; un_ix++)
+                {
+                    if (ptrialevent->num_samples[ev_ix][un_ix])
+                    {
+                        uint32_t* ts = (uint32_t *)ptrialevent->timestamps[ev_ix][un_ix];
+                        // printf(" %" PRIu32, *ts);
+                    }
+                }
+                // printf("\n");
+                
+                uint16_t chan_id = ptrialevent->chan[ev_ix];
+                uint8_t chanType;
+                cbSdkGetChannelType(INST, chan_id, &chanType);
+                if ((chanType == cbCHANTYPE_DIGIN) || (chanType == cbCHANTYPE_SERIAL))
+                {
+                    uint32_t n_samples = ptrialevent->num_samples[ev_ix][0];
+                    if (n_samples > 0)
+                    {
+                        uint32_t* ts = (uint32_t *)ptrialevent->timestamps[ev_ix][0];
+                        printf("%" PRIu32 ":", *ts);
+                    }
+                    uint16_t* wf = (uint16_t*)ptrialevent->waveforms[ev_ix];
+                    for (uint32_t sample_ix = 0; sample_ix < n_samples; sample_ix++)
+                    {
+                        printf(" %" PRIu16, wf[sample_ix]);
+                    }
+                    if (n_samples > 0) printf("\n");
+                }
+            }
+        }
 
-		if (ptrialcont && (ptrialcont->count > 0))
-		{
-			// TODO: Print continous data
-		}
+        if (ptrialcont && (ptrialcont->count > 0))
+        {
+            // TODO: Print continous data
+        }
 
-		// Free allocated memory.
-		if (ptrialevent)
-		{
-			if (ptrialevent->count > 0)
-			{
-				for (size_t ev_ix = 0; ev_ix < ptrialevent->count; ev_ix++)
-				{
-					for (size_t un_ix = 0; un_ix < cbMAXUNITS + 1; un_ix++)
-					{
-						if (ptrialevent->num_samples[ev_ix][un_ix])
-						{
-							free(ptrialevent->timestamps[ev_ix][un_ix]);
-							ptrialevent->timestamps[ev_ix][un_ix] = NULL;
-						}
-					}
+        // Free allocated memory.
+        if (ptrialevent)
+        {
+            if (ptrialevent->count > 0)
+            {
+                for (size_t ev_ix = 0; ev_ix < ptrialevent->count; ev_ix++)
+                {
+                    for (size_t un_ix = 0; un_ix < cbMAXUNITS + 1; un_ix++)
+                    {
+                        if (ptrialevent->num_samples[ev_ix][un_ix])
+                        {
+                            free(ptrialevent->timestamps[ev_ix][un_ix]);
+                            ptrialevent->timestamps[ev_ix][un_ix] = NULL;
+                        }
+                    }
 
-					uint16_t chan_id = ptrialevent->chan[ev_ix];
-					uint8_t chanType;
-					cbSdkGetChannelType(INST, chan_id + 1, &chanType);
-					if ((chanType == cbCHANTYPE_DIGIN) || (chanType == cbCHANTYPE_SERIAL))
-					{
-						free(ptrialevent->waveforms[ev_ix]);
-						ptrialevent->waveforms[ev_ix] = NULL;
-					}
-				}
-			}
-			delete ptrialevent;
-			ptrialevent = nullptr;
-		}
+                    uint16_t chan_id = ptrialevent->chan[ev_ix];
+                    uint8_t chanType;
+                    cbSdkGetChannelType(INST, chan_id + 1, &chanType);
+                    if ((chanType == cbCHANTYPE_DIGIN) || (chanType == cbCHANTYPE_SERIAL))
+                    {
+                        free(ptrialevent->waveforms[ev_ix]);
+                        ptrialevent->waveforms[ev_ix] = NULL;
+                    }
+                }
+            }
+            delete ptrialevent;
+            ptrialevent = nullptr;
+        }
 
-		if (ptrialcont)
-		{
-			if (ptrialcont->count > 0)
-			{
-				// TODO: Free continous data
-			}
-			delete ptrialcont;
-			ptrialcont = nullptr;
-		}
+        if (ptrialcont)
+        {
+            if (ptrialcont->count > 0)
+            {
+                // TODO: Free continous data
+            }
+            delete ptrialcont;
+            ptrialcont = nullptr;
+        }
 
-		if (_kbhit())
-		{
-			kb_ch = _getch();
-		}
-	}
+        if (_kbhit())
+        {
+            kb_ch = _getch();
+        }
+    }
 
     res = testClose();
     if (res < 0)

--- a/cerebus/cbsdk_cython.pxd
+++ b/cerebus/cbsdk_cython.pxd
@@ -65,6 +65,23 @@ cdef extern from "cbhwlib.h":
         cbFILECFG_OPT_SYNCH =        0x00000006
         cbFILECFG_OPT_OPEN =         0x00000007
 
+    cdef enum cbhwlib_cbCHANCAPS:
+        cbCHAN_EXISTS       = 0x00000001  # Channel id is allocated
+        cbCHAN_CONNECTED    = 0x00000002  # Channel is connected and mapped and ready to use
+        cbCHAN_ISOLATED     = 0x00000004  # Channel is electrically isolated
+        cbCHAN_AINP         = 0x00000100  # Channel has analog input capabilities
+        cbCHAN_AOUT         = 0x00000200  # Channel has analog output capabilities
+        cbCHAN_DINP         = 0x00000400  # Channel has digital input capabilities
+        cbCHAN_DOUT         = 0x00000800  # Channel has digital output capabilities
+
+    cdef enum cbhwlib_cbCHANTYPES:
+        cbCHANTYPE_ANAIN  = 0x01
+        cbCHANTYPE_ANAOUT = 0x02
+        cbCHANTYPE_AUDOUT = 0x04
+        cbCHANTYPE_DIGIN  = 0x10
+        cbCHANTYPE_SERIAL = 0x20
+        cbCHANTYPE_DIGOUT = 0x40
+
     ctypedef struct cbSCALING:
         int16_t digmin     # digital value that cooresponds with the anamin value
         int16_t digmax     # digital value that cooresponds with the anamax value
@@ -359,6 +376,7 @@ cdef extern from "cbsdk.h":
     cbSdkResult cbSdkUnsetTrialConfig(uint32_t nInstance, cbSdkTrialType type)
     cbSdkResult cbSdkGetChannelLabel(int nInstance, uint16_t channel, uint32_t * bValid, char * label, uint32_t * userflags, int32_t * position)
     cbSdkResult cbSdkSetChannelLabel(uint32_t nInstance, uint16_t channel, const char * label, uint32_t userflags, int32_t * position)
+    cbSdkResult cbSdkGetChannelType(uint32_t nInstance, uint16_t channel, uint8_t* ch_type)
     # Retrieve data of a trial (NULL means ignore), user should allocate enough buffers beforehand, and trial should not be closed during this call
     cbSdkResult cbSdkGetTrialData(  uint32_t nInstance,
                                     uint32_t bActive, cbSdkTrialEvent * trialevent, cbSdkTrialCont * trialcont,


### PR DESCRIPTION
Fixes #103 
Fixes #104 

* As much as possible, parse packets based on the channel capabilities instead of the channel number.
* Fixes a bug where digital in and serial in events were not being interpreted
* Fixes a bug where digital and serial data couldn't be above 6
* Fixes a bug where events (spikes, digital, and serial) were skipped if they came in packets between the calls to InitTrialData and GetTrialData. Note that user memory allocation occurs between these calls so this is a non-trivial amount of time.
* Updates Python wrapper with above changes.
* Python wrapper also updated to not reset the clock by default, even if the buffer is reset. I only did this where event data were involved. It might be true for continuous data too but I won't be able to test continuous data for a while.