### PR TITLE
Fix NSP clock sync bias: peer HUB offset via shared memory

### DIFF
--- a/pycbsdk/examples/analog_latency_test.py
+++ b/pycbsdk/examples/analog_latency_test.py
@@ -1,59 +1,55 @@
 #!/usr/bin/env python3
 """Analog Input Latency Test — measures the end-to-end timing from host
-audio output to NSP analog input, demonstrating pycbsdk's clock
+audio output to device analog/frontend input, demonstrating pycbsdk's clock
 synchronisation and timestamp conversion.
+
+Can run against a single device (NSP or HUB1) or both simultaneously to
+compare their clock alignment.
 
 Hardware setup
 --------------
-1. Take a **3.5 mm (headphone) → BNC** cable.
+1. Take a **3.5 mm (headphone) → BNC** cable (with a splitter for BOTH mode).
 2. Plug the 3.5 mm end into your computer's **headphone jack**.
-3. Connect the BNC end to **Analog Input 1** on the NSP front panel.
-4. Set your computer's volume to approximately 50 %.  The tone only needs
+3. For the NSP: connect to **Analog Input 1**.
+4. For the HUB1: connect to **FrontEnd channel 1** (via a 1/1000 attenuator).
+5. Set your computer's volume to approximately 50 %.  The tone only needs
    to be large enough to cross a simple amplitude threshold — if the
    detected signal is too weak, increase the volume and re-run.
 
 What the test does
 ------------------
-1. Connects to the NSP and configures Analog Input channel 1 for raw
-   (30 kHz) sampling with DC coupling.
-2. Collects ~1 second of silence to establish a baseline (mean and
-   standard deviation of the noise floor).
+1. Connects to one or both devices and configures the appropriate input
+   channel for raw (30 kHz) sampling with DC coupling.
+2. Collects ~1 second of silence to establish a per-device baseline.
 3. Plays a 400 Hz sine tone (300 ms) through the computer speakers
    ten times, recording ``time.monotonic()`` at the instant each tone
    begins.
-4. In the streaming callback, converts each sample's device timestamp
-   to ``time.monotonic()`` and watches for the first sample whose
-   absolute value exceeds ``baseline_mean + 5 * baseline_std``.
-   That crossing time is the **detected onset** of each tone.
-5. After all tones have been played, reports the latency
-   (``detected_time − play_time``) for each trial plus summary
-   statistics (mean, median, range, std).
+4. In each device's streaming callback, converts each sample's device
+   timestamp to ``time.monotonic()`` and watches for the first sample
+   whose absolute value exceeds ``baseline_mean + 5 * baseline_std``.
+5. Reports per-device latency (``detected_time − play_time``) and, when
+   running both devices, the cross-device onset difference for each trial.
 
-Expected results
-~~~~~~~~~~~~~~~~
-Latency includes the computer's audio output buffer, the DAC, the
-cable, the NSP's ADC, and the UDP network path.  Typical values are
-**5–30 ms** depending on the OS audio stack.  The spread (std) should
-be < 5 ms if clock synchronisation is working correctly.
+Usage::
+
+    python analog_latency_test.py [--device-type NSP|HUB1|BOTH]
 
 Requirements
 ~~~~~~~~~~~~
 * ``pycbsdk`` (installed from this repository)
 * ``numpy``
 * ``sounddevice`` — ``pip install sounddevice``
-
-Usage::
-
-    python analog_latency_test.py [--device-type NSP]
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
 import math
 import sys
 import threading
 import time
+from dataclasses import dataclass, field
 
 import numpy as np
 
@@ -79,12 +75,71 @@ AUDIO_SAMPLE_RATE = 44100 # Sample rate for audio output
 # ---------------------------------------------------------------------------
 # Test parameters
 # ---------------------------------------------------------------------------
-CHANNEL_ID = 1                   # 1-based analog input channel
 BASELINE_DURATION_S = 1.0        # Silence duration for baseline estimation
 N_WARMUP = 3                     # Warmup tones (not analysed)
-N_TRIALS = 10                    # Number of measured tone presentations
+N_TRIALS = 20                    # Number of measured tone presentations
 POST_TONE_WAIT_S = 0.200         # Extra wait after each tone for ringdown
-THRESHOLD_SIGMAS = 5             # Onset threshold = mean + N * std
+NOISE_FLOOR_SIGMAS = 5           # Minimum threshold as multiple of baseline std
+SIGNAL_FRACTION = 0.3            # Threshold as fraction of calibrated peak signal
+
+
+# ---------------------------------------------------------------------------
+# Per-device state
+# ---------------------------------------------------------------------------
+@dataclass
+class DeviceCtx:
+    """Holds all per-device state for the latency test."""
+    name: str
+    dev_type: DeviceType
+    channel_id: int
+    channel_type: ChannelType
+
+    session: Session | None = field(default=None, repr=False)
+    chan_index: int = 0
+
+    # Baseline estimation
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    baseline_samples: list[np.ndarray] = field(default_factory=list)
+    baseline_done: bool = False
+    baseline_mean: float = 0.0
+    baseline_std: float = 1.0
+    threshold: float = math.inf
+
+    # Onset detection — each entry: (trial_index, monotonic_s, device_ns)
+    detections: list[tuple[int, float, int]] = field(default_factory=list)
+    current_trial: int | None = None
+    trial_detected: bool = False
+    trial_earliest: float = 0.0  # reject detections with timestamp before this
+
+    # Auto-calibration
+    calibrating: bool = False
+    calibration_samples: list[np.ndarray] = field(default_factory=list)
+
+    # Monotonicity tracking
+    last_mono_time: float | None = None
+    mono_violations: int = 0
+    mono_worst_ms: float = 0.0
+    mono_total_samples: int = 0
+
+    # Clock sync monitoring — each entry: (elapsed_s, offset_ns, uncertainty_ns)
+    clock_log: list[tuple[float, int | None, int | None]] = field(
+        default_factory=list
+    )
+
+
+# Map CLI argument to one or two device contexts.
+DEVICE_PRESETS: dict[str, list[DeviceCtx]] = {
+    "NSP": [
+        DeviceCtx("NSP", DeviceType.NSP, channel_id=1, channel_type=ChannelType.ANALOG_IN),
+    ],
+    "HUB1": [
+        DeviceCtx("HUB1", DeviceType.HUB1, channel_id=1, channel_type=ChannelType.FRONTEND),
+    ],
+    "BOTH": [
+        DeviceCtx("NSP", DeviceType.NSP, channel_id=1, channel_type=ChannelType.ANALOG_IN),
+        DeviceCtx("HUB1", DeviceType.HUB1, channel_id=1, channel_type=ChannelType.FRONTEND),
+    ],
+}
 
 
 def generate_tone() -> np.ndarray:
@@ -98,161 +153,364 @@ def generate_tone() -> np.ndarray:
     return (TONE_AMPLITUDE * np.sin(2 * np.pi * TONE_FREQ_HZ * t) * ramp).astype(np.float32)
 
 
+def register_callback(ctx: DeviceCtx) -> None:
+    """Register the streaming callback that performs baseline collection
+    and onset detection for *ctx*."""
+    sess = ctx.session
+
+    @sess.on_group_batch(SampleRate.SR_RAW)
+    def on_raw_batch(samples: np.ndarray, timestamps: np.ndarray):
+        # -- Monotonicity check on every converted timestamp --
+        for ts in timestamps:
+            t = sess.device_to_monotonic(int(ts))
+            ctx.mono_total_samples += 1
+            if ctx.last_mono_time is not None and t < ctx.last_mono_time:
+                ctx.mono_violations += 1
+                jump_ms = (ctx.last_mono_time - t) * 1000
+                ctx.mono_worst_ms = max(ctx.mono_worst_ms, jump_ms)
+            ctx.last_mono_time = t
+
+        ch_data = samples[:, ctx.chan_index].astype(np.float64)
+
+        with ctx.lock:
+            if not ctx.baseline_done:
+                ctx.baseline_samples.append(ch_data.copy())
+                return
+
+            if ctx.calibrating:
+                ctx.calibration_samples.append(ch_data.copy())
+                return
+
+            if ctx.current_trial is None or ctx.trial_detected:
+                return
+
+            abs_data = np.abs(ch_data - ctx.baseline_mean)
+            above = np.where(abs_data > ctx.threshold)[0]
+            if len(above) == 0:
+                return
+
+            onset_device_ns = int(timestamps[above[0]])
+            onset_monotonic = sess.device_to_monotonic(onset_device_ns)
+
+            # Reject detections from buffered data that predates this trial.
+            if onset_monotonic < ctx.trial_earliest:
+                return
+
+            ctx.detections.append((ctx.current_trial, onset_monotonic, onset_device_ns))
+            ctx.trial_detected = True
+
+
+def _clock_monitor(
+    devices: list[DeviceCtx],
+    stop: threading.Event,
+    t0: float,
+    interval: float = 0.2,
+) -> None:
+    """Background thread: sample clock_offset_ns / uncertainty per device."""
+    while not stop.is_set():
+        elapsed = time.monotonic() - t0
+        for ctx in devices:
+            if ctx.session:
+                offset = ctx.session.clock_offset_ns
+                uncert = ctx.session.clock_uncertainty_ns
+                ctx.clock_log.append((elapsed, offset, uncert))
+        stop.wait(interval)
+
+
+DATA_FALLBACK_UNCERT_NS = 700_000  # matches ONE_WAY_DELAY_ESTIMATE_NS in C++
+
+
+def print_clock_timeline(ctx: DeviceCtx) -> None:
+    """Print clock sync evolution and highlight probe→fallback transition."""
+    if not ctx.clock_log:
+        return
+
+    # Compute a common base to make offsets readable
+    first_offset = next(
+        (o for _, o, _ in ctx.clock_log if o is not None), None
+    )
+    base_ns = first_offset if first_offset is not None else 0
+
+    print(f"--- {ctx.name} clock sync timeline ---")
+    if base_ns:
+        print(f"  (offsets shown relative to {base_ns / 1e6:+.3f} ms)")
+
+    prev_method: str | None = None
+    transition_idx: int | None = None
+    probe_offsets: list[int] = []
+    data_offsets: list[int] = []
+
+    for i, (elapsed, offset, uncert) in enumerate(ctx.clock_log):
+        if offset is None:
+            method = "none"
+            offset_ms_str = "      N/A"
+            uncert_ms_str = "  N/A"
+        else:
+            method = "data" if uncert == DATA_FALLBACK_UNCERT_NS else "probe"
+            rel_ms = (offset - base_ns) / 1e6
+            offset_ms_str = f"{rel_ms:+10.3f}"
+            uncert_ms_str = f"{uncert / 1e6:5.2f}" if uncert is not None else "  N/A"
+            if method == "probe":
+                probe_offsets.append(offset)
+            else:
+                data_offsets.append(offset)
+
+        marker = ""
+        if prev_method is not None and method != prev_method:
+            marker = f"  ← {prev_method}→{method}"
+            if transition_idx is None:
+                transition_idx = i
+        prev_method = method
+
+        print(f"  t={elapsed:5.1f}s  offset={offset_ms_str} ms  "
+              f"uncert={uncert_ms_str} ms  [{method:5s}]{marker}")
+
+    # Summary
+    print()
+    if probe_offsets:
+        p = (np.array(probe_offsets) - base_ns) / 1e6
+        print(f"  Probe phase:  {len(probe_offsets)} samples, "
+              f"offset range [{np.min(p):+.3f}, {np.max(p):+.3f}] ms (rel), "
+              f"spread {np.max(p) - np.min(p):.3f} ms")
+    if data_offsets:
+        d = (np.array(data_offsets) - base_ns) / 1e6
+        print(f"  Data phase:   {len(data_offsets)} samples, "
+              f"offset range [{np.min(d):+.3f}, {np.max(d):+.3f}] ms (rel), "
+              f"spread {np.max(d) - np.min(d):.3f} ms")
+        # Check if floor is holding (offset should only decrease or stay)
+        decreases = sum(1 for a, b in zip(data_offsets, data_offsets[1:]) if b < a)
+        holds = sum(1 for a, b in zip(data_offsets, data_offsets[1:]) if b == a)
+        increases = sum(1 for a, b in zip(data_offsets, data_offsets[1:]) if b > a)
+        print(f"  Data floor:   {decreases} decreases, {holds} holds, "
+              f"{increases} increases (expect 0 increases if floor is enforced)")
+    if transition_idx is not None:
+        t_elapsed = ctx.clock_log[transition_idx][0]
+        print(f"  Transition:   at t={t_elapsed:.1f}s (sample {transition_idx})")
+        # Show offset jump at transition
+        pre = ctx.clock_log[transition_idx - 1] if transition_idx > 0 else None
+        post = ctx.clock_log[transition_idx]
+        if pre and pre[1] is not None and post[1] is not None:
+            jump_ms = (post[1] - pre[1]) / 1e6
+            print(f"  Offset jump:  {(pre[1]-base_ns)/1e6:+.3f} → "
+                  f"{(post[1]-base_ns)/1e6:+.3f} ms (rel) "
+                  f"(Δ = {jump_ms:+.3f} ms)")
+    elif probe_offsets and not data_offsets:
+        print("  No fallback transition — stayed on probes throughout.")
+    elif data_offsets and not probe_offsets:
+        print("  Started directly in data-fallback mode (probes never reliable).")
+    print()
+
+
+def print_device_results(ctx: DeviceCtx, play_times: list[float]) -> None:
+    """Print per-device latency results."""
+    print(f"--- {ctx.name} ---")
+
+    if not ctx.detections:
+        print("  No tones detected!  Check cable and volume.")
+        print()
+        return
+
+    latencies_ms: list[float] = []
+    for trial_idx, detected_t, device_ns in ctx.detections:
+        latency_ms = (detected_t - play_times[trial_idx]) * 1000
+        latencies_ms.append(latency_ms)
+        print(f"  Trial {trial_idx + 1:2d}: "
+              f"mono={detected_t:.6f}  "
+              f"dev_ns={device_ns}  "
+              f"latency={latency_ms:+7.2f} ms")
+
+    lat = np.array(latencies_ms)
+    print()
+    print(f"  Detected:  {len(ctx.detections)}/{N_TRIALS} trials")
+    print(f"  Mean:      {np.mean(lat):+.2f} ms")
+    print(f"  Median:    {np.median(lat):+.2f} ms")
+    print(f"  Std:       {np.std(lat):.2f} ms")
+    print(f"  Range:     [{np.min(lat):+.2f}, {np.max(lat):+.2f}] ms")
+
+    uncert = ctx.session.clock_uncertainty_ns
+    if uncert is not None:
+        print(f"  Clock sync uncertainty: {uncert / 1e6:.2f} ms")
+
+    print()
+    print(f"  Timestamp monotonicity: {ctx.mono_total_samples} samples checked")
+    if ctx.mono_violations == 0:
+        print("  No backwards jumps detected.")
+    elif ctx.mono_violations <= 2 and ctx.mono_worst_ms > 50:
+        print(f"  {ctx.mono_violations} backwards jump(s) "
+              f"(worst: {ctx.mono_worst_ms:.1f} ms) — initial clock sync "
+              f"settling, not a steady-state issue.")
+    else:
+        print(f"  {ctx.mono_violations} backwards jumps "
+              f"(worst: {ctx.mono_worst_ms:.3f} ms)")
+    print()
+
+
+def print_comparison(devices: list[DeviceCtx]) -> None:
+    """Print cross-device onset comparison (BOTH mode)."""
+    # Build trial_idx → (monotonic_s, device_ns) maps per device.
+    det_maps = [
+        {idx: (mono, dev_ns) for idx, mono, dev_ns in ctx.detections}
+        for ctx in devices
+    ]
+    common_trials = sorted(
+        set.intersection(*(set(d.keys()) for d in det_maps))
+    )
+
+    d0, d1 = devices[0].name, devices[1].name
+
+    print("=" * 60)
+    print("Cross-device comparison (PTP / device timestamps)")
+    print("=" * 60)
+
+    if not common_trials:
+        print("  No trials detected by both devices — cannot compare.")
+        return
+
+    ptp_diffs_ms: list[float] = []
+    for trial_idx in common_trials:
+        ns0 = det_maps[0][trial_idx][1]
+        ns1 = det_maps[1][trial_idx][1]
+        diff_ms = (ns1 - ns0) / 1e6
+        ptp_diffs_ms.append(diff_ms)
+        print(f"  Trial {trial_idx + 1:2d}: "
+              f"{d0}={ns0}  {d1}={ns1}  "
+              f"Δ({d1}−{d0})={diff_ms:+.2f} ms")
+
+    ptp = np.array(ptp_diffs_ms)
+    print()
+    print(f"  Mean Δ:    {np.mean(ptp):+.2f} ms")
+    print(f"  Median Δ:  {np.median(ptp):+.2f} ms")
+    print(f"  Std Δ:     {np.std(ptp):.2f} ms")
+    print(f"  Range Δ:   [{np.min(ptp):+.2f}, {np.max(ptp):+.2f}] ms")
+    print()
+    print("  If PTP Δ ≈ 0, both device clocks agree and the bias is in")
+    print("  device_to_monotonic.  If PTP Δ ≠ 0, the PTP clocks themselves")
+    print("  are misaligned.")
+
+    print()
+    print("=" * 60)
+    print("Cross-device comparison (converted monotonic timestamps)")
+    print("=" * 60)
+
+    mono_diffs_ms: list[float] = []
+    for trial_idx in common_trials:
+        t0 = det_maps[0][trial_idx][0]
+        t1 = det_maps[1][trial_idx][0]
+        diff_ms = (t1 - t0) * 1000
+        mono_diffs_ms.append(diff_ms)
+        print(f"  Trial {trial_idx + 1:2d}: "
+              f"{d0}={t0:.6f}  {d1}={t1:.6f}  "
+              f"Δ({d1}−{d0})={diff_ms:+.2f} ms")
+
+    mono = np.array(mono_diffs_ms)
+    print()
+    print(f"  Mean Δ:    {np.mean(mono):+.2f} ms")
+    print(f"  Median Δ:  {np.median(mono):+.2f} ms")
+    print(f"  Std Δ:     {np.std(mono):.2f} ms")
+    print(f"  Range Δ:   [{np.min(mono):+.2f}, {np.max(mono):+.2f}] ms")
+    print()
+    print("  Positive Δ means the second device detects the tone later.")
+    print("  Mono Δ − PTP Δ = bias introduced by device_to_monotonic.")
+
+
 def main():
-    parser = argparse.ArgumentParser(description=__doc__,
-                                     formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--device-type", default="NSP",
-                        help="pycbsdk DeviceType name (default: NSP)")
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--device-type",
+        default="NSP",
+        choices=["NSP", "HUB1", "BOTH"],
+        help="Device(s) to test (default: NSP)",
+    )
     args = parser.parse_args()
 
-    dev_type = DeviceType[args.device_type.upper()]
+    devices = DEVICE_PRESETS[args.device_type.upper()]
 
-    # -----------------------------------------------------------------------
-    # 1. Connect and configure
-    # -----------------------------------------------------------------------
-    print(f"Connecting to {dev_type.name}...")
-    with Session(device_type=dev_type) as sess:
+    # ------------------------------------------------------------------
+    # 1. Connect all devices
+    # ------------------------------------------------------------------
+    with contextlib.ExitStack() as stack:
+        for ctx in devices:
+            print(f"Connecting to {ctx.name}...")
+            ctx.session = stack.enter_context(Session(device_type=ctx.dev_type))
+
         deadline = time.monotonic() + 10
-        while not sess.running:
-            if time.monotonic() > deadline:
-                sys.exit("Session did not start within 10 s — is the device on?")
-            time.sleep(0.1)
-
-        print(f"  Processor: {sess.proc_ident}")
-        print(f"  Clock uncertainty: {(sess.clock_uncertainty_ns or 0) / 1e6:.2f} ms")
+        for ctx in devices:
+            while not ctx.session.running:
+                if time.monotonic() > deadline:
+                    sys.exit(f"[{ctx.name}] Session did not start within 10 s "
+                             "— is the device on?")
+                time.sleep(0.1)
+            print(f"  [{ctx.name}] Processor: {ctx.session.proc_ident}")
+            print(f"  [{ctx.name}] Clock uncertainty: "
+                  f"{(ctx.session.clock_uncertainty_ns or 0) / 1e6:.2f} ms")
         print()
 
-        # Configure: 1 channel, raw (30 kHz), DC coupling
-        sess.set_channel_smpgroup(CHANNEL_ID, SampleRate.SR_RAW)
-        sess.set_ac_input_coupling(1, ChannelType.ANALOG_IN, False)
-        sess.sync()
-        print(f"  Channel {CHANNEL_ID} configured: SR_RAW, DC coupling")
+        # Start clock sync monitor immediately
+        clock_stop = threading.Event()
+        clock_t0 = time.monotonic()
+        clock_thread = threading.Thread(
+            target=_clock_monitor,
+            args=(devices, clock_stop, clock_t0),
+            daemon=True,
+        )
+        clock_thread.start()
 
-        raw_channels = sess.get_group_channels(int(SampleRate.SR_RAW))
-        if CHANNEL_ID not in raw_channels:
-            sys.exit(f"Channel {CHANNEL_ID} not in RAW group — check device type "
-                     f"(got group: {raw_channels})")
+        # --------------------------------------------------------------
+        # 2. Configure channels and register callbacks
+        # --------------------------------------------------------------
+        for ctx in devices:
+            sess = ctx.session
+            sess.set_channel_smpgroup(ctx.channel_id, SampleRate.SR_RAW)
+            sess.sync()
+            sess.set_ac_input_coupling(1, ctx.channel_type, False)
+            sess.sync()
 
-        # Work out which index our channel occupies in the group data array.
-        # The on_group_batch callback delivers an (n_samples, n_channels)
-        # array where columns correspond to get_group_channels() order.
-        chan_index = raw_channels.index(CHANNEL_ID)
+            raw_channels = sess.get_group_channels(int(SampleRate.SR_RAW))
+            if ctx.channel_id not in raw_channels:
+                sys.exit(f"[{ctx.name}] Channel {ctx.channel_id} not in RAW "
+                         f"group (got: {raw_channels})")
+            ctx.chan_index = raw_channels.index(ctx.channel_id)
 
-        # -------------------------------------------------------------------
-        # 2. Prepare tone
-        # -------------------------------------------------------------------
+            print(f"  [{ctx.name}] Channel {ctx.channel_id} configured: "
+                  f"SR_RAW, DC coupling ({ctx.channel_type.name})")
+            register_callback(ctx)
+
+        # --------------------------------------------------------------
+        # 3. Prepare tone
+        # --------------------------------------------------------------
         tone = generate_tone()
-        print(f"  Tone: {TONE_FREQ_HZ} Hz, {TONE_DURATION_S*1000:.0f} ms, "
-              f"{AUDIO_SAMPLE_RATE} Hz audio sample rate")
-        print()
+        print(f"\n  Tone: {TONE_FREQ_HZ} Hz, {TONE_DURATION_S * 1000:.0f} ms, "
+              f"{AUDIO_SAMPLE_RATE} Hz audio sample rate\n")
 
-        # -------------------------------------------------------------------
-        # 3. Register streaming callback
-        # -------------------------------------------------------------------
-        # Shared state between callback and main thread.
-        # The callback runs on the SDK's internal thread, so we use a lock.
-        lock = threading.Lock()
-        baseline_samples: list[np.ndarray] = []
-        baseline_done = False
-        baseline_mean = 0.0
-        baseline_std = 1.0
-        threshold = math.inf  # will be set after baseline
-
-        # Each entry: (trial_index, detected_monotonic_time)
-        detections: list[tuple[int, float]] = []
-        current_trial: int | None = None  # set by main thread when tone plays
-        trial_detected = False
-
-        # Monotonicity tracking: detect backwards jumps in converted timestamps
-        last_mono_time: float | None = None
-        mono_violations = 0
-        mono_worst_ms = 0.0
-        mono_total_samples = 0
-
-        @sess.on_group_batch(SampleRate.SR_RAW)
-        def on_raw_batch(samples: np.ndarray, timestamps: np.ndarray):
-            """Process a batch of raw samples.
-
-            Parameters
-            ----------
-            samples : ndarray, shape (n_samples, n_channels), dtype int16
-                Raw ADC values for all channels in the RAW group.
-            timestamps : ndarray, shape (n_samples,), dtype uint64
-                Device timestamps in nanoseconds for each sample.
-            """
-            nonlocal baseline_done, baseline_mean, baseline_std, threshold
-            nonlocal current_trial, trial_detected
-            nonlocal last_mono_time, mono_violations, mono_worst_ms, mono_total_samples
-
-            # Check every converted timestamp for monotonicity.
-            for ts in timestamps:
-                t = sess.device_to_monotonic(int(ts))
-                mono_total_samples += 1
-                if last_mono_time is not None and t < last_mono_time:
-                    mono_violations += 1
-                    jump_ms = (last_mono_time - t) * 1000
-                    mono_worst_ms = max(mono_worst_ms, jump_ms)
-                last_mono_time = t
-
-            # Extract our channel's column
-            ch_data = samples[:, chan_index].astype(np.float64)
-
-            with lock:
-                if not baseline_done:
-                    # Accumulate baseline samples
-                    baseline_samples.append(ch_data.copy())
-                    return
-
-                if current_trial is None or trial_detected:
-                    return  # Not in an active trial, or already detected this one
-
-                # Look for the first sample exceeding the threshold.
-                abs_data = np.abs(ch_data - baseline_mean)
-                above = np.where(abs_data > threshold)[0]
-                if len(above) == 0:
-                    return
-
-                # Convert the device timestamp of the onset sample to
-                # time.monotonic() — this is the key demonstration.
-                onset_device_ns = int(timestamps[above[0]])
-                onset_monotonic = sess.device_to_monotonic(onset_device_ns)
-
-                detections.append((current_trial, onset_monotonic))
-                trial_detected = True
-
-        # -------------------------------------------------------------------
-        # 4. Collect baseline
-        # -------------------------------------------------------------------
+        # --------------------------------------------------------------
+        # 4. Collect baseline (all devices simultaneously)
+        # --------------------------------------------------------------
         print(f"Collecting {BASELINE_DURATION_S} s of baseline (silence)...")
         time.sleep(BASELINE_DURATION_S)
 
-        with lock:
-            all_baseline = np.concatenate(baseline_samples)
-            baseline_mean = float(np.mean(all_baseline))
-            baseline_std = float(np.std(all_baseline))
-            threshold = THRESHOLD_SIGMAS * baseline_std
-            baseline_done = True
-
-        print(f"  Baseline: mean={baseline_mean:.1f}  std={baseline_std:.1f}  "
-              f"threshold=±{threshold:.1f}  ({len(all_baseline)} samples)")
-        if baseline_std < 1.0:
-            print("  WARNING: baseline std is very low — is the cable connected?")
+        for ctx in devices:
+            with ctx.lock:
+                all_baseline = np.concatenate(ctx.baseline_samples)
+                ctx.baseline_mean = float(np.mean(all_baseline))
+                ctx.baseline_std = float(np.std(all_baseline))
+                ctx.baseline_done = True
+            print(f"  [{ctx.name}] Baseline: mean={ctx.baseline_mean:.1f}  "
+                  f"std={ctx.baseline_std:.1f}  "
+                  f"({len(all_baseline)} samples)")
+            if ctx.baseline_std < 1.0:
+                print(f"  [{ctx.name}] WARNING: baseline std is very low "
+                      "— is the cable connected?")
         print()
 
-        # -------------------------------------------------------------------
-        # 5–7. Play tones and record play times
-        # -------------------------------------------------------------------
-        # Use a callback-based output stream for precise timing.
-        # The callback fires every time the audio driver needs a new
-        # buffer.  When we want to play a tone, we set ``tone_pending``
-        # and record ``time.monotonic()`` inside the FIRST callback that
-        # copies tone data — that is the closest we can get to the
-        # actual moment audio exits the OS mixer.  The remaining
-        # latency after that point (driver buffer → DAC → cable → ADC)
-        # is hardware-fixed and consistent.
+        # --------------------------------------------------------------
+        # 5. Set up audio output with callback-based timing
+        # --------------------------------------------------------------
         tone_frames = len(tone)
-        tone_pos = 0        # current read position in tone array
-        tone_pending = False # main thread sets True to trigger a tone
+        tone_pos = 0
+        tone_pending = False
         play_times: list[float] = []
         play_lock = threading.Lock()
 
@@ -260,8 +518,6 @@ def main():
             nonlocal tone_pos, tone_pending
             with play_lock:
                 if tone_pending and tone_pos == 0:
-                    # First callback after tone was armed — record the
-                    # moment we start filling the driver's buffer.
                     play_times.append(time.monotonic())
                     tone_pending = False
 
@@ -284,100 +540,125 @@ def main():
         stream.start()
         print(f"  Audio output latency: {stream.latency * 1000:.1f} ms")
 
-        # Warmup: play a few tones to prime the audio pipeline.
-        # CoreAudio (macOS) buffers the first 1-2 callbacks before the
-        # DAC actually starts, adding ~250 ms to the first tones.
+        # --------------------------------------------------------------
+        # 6. Warmup tones
+        # --------------------------------------------------------------
         print(f"  Warming up ({N_WARMUP} tones)...")
         for _ in range(N_WARMUP):
             with play_lock:
                 tone_pos = 0
                 tone_pending = True
             time.sleep(TONE_DURATION_S + POST_TONE_WAIT_S)
-        # Discard any play_times recorded during warmup
         play_times.clear()
+
+        # --------------------------------------------------------------
+        # 7. Auto-calibrate thresholds: play one tone with a warm audio
+        #    pipeline and measure peak signal level on each device.
+        # --------------------------------------------------------------
+        print("  Calibrating thresholds...")
+        for ctx in devices:
+            with ctx.lock:
+                ctx.calibrating = True
+        with play_lock:
+            tone_pos = 0
+            tone_pending = True
+        time.sleep(TONE_DURATION_S + POST_TONE_WAIT_S)
+        play_times.clear()
+
+        for ctx in devices:
+            with ctx.lock:
+                ctx.calibrating = False
+                if ctx.calibration_samples:
+                    cal_data = np.concatenate(ctx.calibration_samples)
+                    peak_dev = float(
+                        np.max(np.abs(cal_data - ctx.baseline_mean))
+                    )
+                    noise_floor = NOISE_FLOOR_SIGMAS * ctx.baseline_std
+                    ctx.threshold = max(noise_floor, SIGNAL_FRACTION * peak_dev)
+                else:
+                    peak_dev = 0.0
+                    ctx.threshold = NOISE_FLOOR_SIGMAS * ctx.baseline_std
+            if peak_dev > 0:
+                print(f"  [{ctx.name}] Peak: {peak_dev:.1f}  "
+                      f"Threshold: ±{ctx.threshold:.1f} "
+                      f"({ctx.threshold / ctx.baseline_std:.1f}σ, "
+                      f"{100 * ctx.threshold / peak_dev:.0f}% of peak)")
+            else:
+                print(f"  [{ctx.name}] WARNING: no calibration signal, "
+                      f"using {NOISE_FLOOR_SIGMAS}σ threshold")
         print()
 
+        # --------------------------------------------------------------
+        # 7. Measured trials
+        # --------------------------------------------------------------
         for i in range(N_TRIALS):
-            with lock:
-                current_trial = i
-                trial_detected = False
+            now = time.monotonic()
+            for ctx in devices:
+                with ctx.lock:
+                    ctx.current_trial = i
+                    ctx.trial_detected = False
+                    ctx.trial_earliest = now
 
-            # Arm the tone: the audio callback will record the play time
-            # on the very first buffer fill.
             with play_lock:
                 tone_pos = 0
                 tone_pending = True
 
-            # Wait for the tone to finish playing out plus margin.
             time.sleep(TONE_DURATION_S + POST_TONE_WAIT_S)
 
-            with lock:
-                status = "detected" if trial_detected else "MISSED"
-            print(f"  Trial {i+1:2d}/{N_TRIALS}: {status}")
+            statuses = []
+            for ctx in devices:
+                with ctx.lock:
+                    statuses.append(
+                        "detected" if ctx.trial_detected else "MISSED"
+                    )
+            status_str = "  ".join(
+                f"{ctx.name}={s}" for ctx, s in zip(devices, statuses)
+            )
+            print(f"  Trial {i + 1:2d}/{N_TRIALS}: {status_str}")
 
         stream.stop()
         stream.close()
 
-        # Stop looking for onsets
-        with lock:
-            current_trial = None
+        for ctx in devices:
+            with ctx.lock:
+                ctx.current_trial = None
 
-        # -------------------------------------------------------------------
-        # 8–9. Report results
-        # -------------------------------------------------------------------
+        # Stop clock monitor
+        clock_stop.set()
+        clock_thread.join(timeout=2)
+
+        # --------------------------------------------------------------
+        # 8. Report results
+        # --------------------------------------------------------------
         print()
         print("=" * 60)
         print("Results")
         print("=" * 60)
+        print()
 
-        if not detections:
-            print("No tones were detected!  Check:")
-            print("  • Is the cable connected to Analog Input 1?")
+        for ctx in devices:
+            print_clock_timeline(ctx)
+
+        any_detected = False
+        for ctx in devices:
+            if ctx.detections:
+                any_detected = True
+            print_device_results(ctx, play_times)
+
+        if not any_detected:
+            print("No tones were detected on any device!  Check:")
+            print("  • Are the cables connected?")
             print("  • Is the computer volume turned up?")
-            print("  • Try increasing TONE_AMPLITUDE or decreasing THRESHOLD_SIGMAS.")
+            print("  • Try increasing TONE_AMPLITUDE or decreasing "
+                  "THRESHOLD_SIGMAS.")
             sys.exit(1)
 
-        latencies_ms: list[float] = []
-        for trial_idx, detected_t in detections:
-            latency_ms = (detected_t - play_times[trial_idx]) * 1000
-            latencies_ms.append(latency_ms)
-            print(f"  Trial {trial_idx+1:2d}: "
-                  f"play={play_times[trial_idx]:.6f}  "
-                  f"detect={detected_t:.6f}  "
-                  f"latency={latency_ms:+7.2f} ms")
-
-        lat = np.array(latencies_ms)
-        print()
-        print(f"  Detected:  {len(detections)}/{N_TRIALS} trials")
-        print(f"  Mean:      {np.mean(lat):+.2f} ms")
-        print(f"  Median:    {np.median(lat):+.2f} ms")
-        print(f"  Std:       {np.std(lat):.2f} ms")
-        print(f"  Range:     [{np.min(lat):+.2f}, {np.max(lat):+.2f}] ms")
-        print()
-
-        uncert = sess.clock_uncertainty_ns
-        if uncert is not None:
-            print(f"  Clock sync uncertainty: {uncert / 1e6:.2f} ms")
-            print(f"  (Latency std should be comparable to this value.)")
-
-        print()
-        print(f"  Timestamp monotonicity: {mono_total_samples} samples checked")
-        if mono_violations == 0:
-            print("  No backwards jumps detected.")
-        elif mono_violations <= 2 and mono_worst_ms > 50:
-            # A single large jump is the expected one-time correction when
-            # the clock sync switches from probe-based to data-packet-based
-            # offset estimation (happens ~4-6 s after connect).
-            print(f"  {mono_violations} backwards jump(s) "
-                  f"(worst: {mono_worst_ms:.1f} ms) — initial clock sync "
-                  f"settling, not a steady-state issue.")
-        else:
-            print(f"  {mono_violations} backwards jumps "
-                  f"(worst: {mono_worst_ms:.3f} ms)")
+        if len(devices) > 1:
+            print_comparison(devices)
 
         print()
         print("The latency includes: OS audio buffer → DAC → cable → "
-              "NSP ADC → UDP → clock conversion.")
+              "device ADC → UDP → clock conversion.")
 
 
 if __name__ == "__main__":

--- a/src/cbdev/include/cbdev/clock_sync.h
+++ b/src/cbdev/include/cbdev/clock_sync.h
@@ -75,6 +75,13 @@ public:
     /// Used only when probesAreReliable() returns false.
     void addDataPacketSample(uint64_t device_time_ns, time_point recv_local);
 
+    /// Inject an externally-determined offset (e.g., from a peer device's
+    /// shared memory).  Takes immediate effect and overrides probe/data
+    /// estimates in toLocalTime()/toDeviceTime().  Call with nullopt to
+    /// clear and revert to internal estimates.
+    void setExternalOffset(std::optional<int64_t> offset_ns,
+                           std::optional<int64_t> uncertainty_ns = std::nullopt);
+
 private:
     mutable std::mutex m_mutex;
     Config m_config;
@@ -96,6 +103,11 @@ private:
 
     std::optional<int64_t> m_current_offset_ns;
     std::optional<int64_t> m_current_uncertainty_ns;
+
+    // External offset injected by setExternalOffset() — takes priority
+    // over internal estimates when set.
+    std::optional<int64_t> m_external_offset_ns;
+    std::optional<int64_t> m_external_uncertainty_ns;
 
     void recomputeEstimate();       // called with lock held
     void pruneExpired(time_point now);  // called with lock held

--- a/src/cbdev/include/cbdev/clock_sync.h
+++ b/src/cbdev/include/cbdev/clock_sync.h
@@ -34,7 +34,7 @@ public:
 
     struct Config {
         double forward_delay_fraction = 0.5; // α: assumed D1/(D1+D2)
-        size_t max_probe_samples = 8;
+        size_t max_probe_samples = 80;
         std::chrono::seconds max_probe_age = std::chrono::seconds{15};
     };
 

--- a/src/cbdev/include/cbdev/device_session.h
+++ b/src/cbdev/include/cbdev/device_session.h
@@ -330,6 +330,12 @@ public:
     /// @return Uncertainty in nanoseconds, or nullopt if no sync data available
     [[nodiscard]] virtual std::optional<int64_t> getUncertaintyNs() const = 0;
 
+    /// Inject an externally-determined offset (e.g., from a peer device).
+    /// When set, overrides internal probe/data estimates in toLocalTime().
+    /// Pass nullopt to clear and revert to internal estimates.
+    virtual void setExternalClockOffset(std::optional<int64_t> offset_ns,
+                                        std::optional<int64_t> uncertainty_ns = std::nullopt) = 0;
+
     /// @}
 };
 

--- a/src/cbdev/src/clock_sync.cpp
+++ b/src/cbdev/src/clock_sync.cpp
@@ -109,6 +109,21 @@ std::optional<int64_t> ClockSync::getUncertaintyNs() const {
     return m_current_uncertainty_ns;
 }
 
+void ClockSync::setExternalOffset(std::optional<int64_t> offset_ns,
+                                   std::optional<int64_t> uncertainty_ns) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_external_offset_ns = offset_ns;
+    m_external_uncertainty_ns = uncertainty_ns;
+    if (offset_ns) {
+        m_current_offset_ns = offset_ns;
+        if (uncertainty_ns)
+            m_current_uncertainty_ns = uncertainty_ns;
+    } else {
+        // Cleared — revert to internal estimate
+        recomputeEstimate();
+    }
+}
+
 bool ClockSync::probesAreReliable() const {
     std::lock_guard<std::mutex> lock(m_mutex);
     return probeSpreadOk();
@@ -174,6 +189,14 @@ void ClockSync::addDataPacketSample(const uint64_t device_time_ns, const time_po
 }
 
 void ClockSync::recomputeEstimate() {
+    // External offset (from peer device shmem) takes unconditional priority.
+    if (m_external_offset_ns) {
+        m_current_offset_ns = m_external_offset_ns;
+        if (m_external_uncertainty_ns)
+            m_current_uncertainty_ns = m_external_uncertainty_ns;
+        return;
+    }
+
     // Strategy:
     //   1. If probes are reliable (tight spread), use glitch-filtered
     //      max-offset probe.  This is the HUB1 path.

--- a/src/cbdev/src/clock_sync.cpp
+++ b/src/cbdev/src/clock_sync.cpp
@@ -10,6 +10,8 @@
 #include "cbdev/clock_sync.h"
 #include <algorithm>
 #include <cmath>
+#include <numeric>
+#include <vector>
 
 namespace cbdev {
 
@@ -116,11 +118,9 @@ void ClockSync::addDataPacketSample(const uint64_t device_time_ns, const time_po
     std::lock_guard<std::mutex> lock(m_mutex);
 
     const int64_t recv_ns = to_ns(recv_local);
-    // offset = device_time - recv_time.
-    // This overestimates the true offset by the one-way network delay
-    // (host→device path isn't measured).  Over many samples the minimum
-    // offset will approach the true value because the minimum corresponds
-    // to the least-queued packet.
+    // raw_offset = device_time - recv_time = true_offset - one_way_delay.
+    // The maximum raw_offset (minimum one-way delay) is closest to the
+    // true offset, regardless of clock epoch.
     const int64_t offset_ns = static_cast<int64_t>(device_time_ns) - recv_ns;
 
     // Detect clock jumps (same logic as addProbeSample)
@@ -144,61 +144,109 @@ void ClockSync::addDataPacketSample(const uint64_t device_time_ns, const time_po
         m_data_samples.pop_front();
     }
 
-    // Pick minimum offset (closest to true offset = least network delay).
-    // Add a constant to compensate for the one-way acquisition-to-
-    // transmission delay that this method can't measure.  Without
-    // this correction the converted timestamps appear in the future.
-    // 0.7 ms is the observed lower bound on the device's capture-to-
-    // send latency (ADC sample → UDP datagram on the wire).
-    //
-    // Pick minimum offset (closest to true offset = least network delay).
-    // Once established, only allow the offset to DECREASE (= converted
-    // timestamps move forward in time, never backwards).
-    // device_to_monotonic(D) = D - offset, so a smaller offset shifts
-    // results later.  When old minimum-delay samples expire the raw
-    // minimum jumps up, but we hold the previous lower value to
-    // preserve monotonicity.
-    //
-    // The monotonicity constraint is tracked separately from probe-based
-    // offsets (m_data_floor_ns) so that the initial transition from a
-    // stale probe offset to the data-based estimate isn't blocked.
+    // Compute fallback offset: max raw_offset with gap-based glitch
+    // rejection, plus a small correction for residual network delay.
+    // Recomputed from the current window each time (no permanent floor).
     if (!m_data_samples.empty()) {
         constexpr int64_t ONE_WAY_DELAY_ESTIMATE_NS = 700'000;  // 0.7 ms
-        int64_t best = m_data_samples.front().offset_ns;
+        constexpr int64_t DATA_GAP_THRESHOLD_NS = 5'000'000;    // 5 ms
+
+        // Sort offsets to find the glitch-filtered max.
+        std::vector<int64_t> offsets;
+        offsets.reserve(m_data_samples.size());
         for (const auto& s : m_data_samples)
-            best = std::min(best, s.offset_ns);
-        const int64_t candidate = best + ONE_WAY_DELAY_ESTIMATE_NS;
-        if (!m_data_floor_ns || candidate < *m_data_floor_ns) {
-            m_data_floor_ns = candidate;
+            offsets.push_back(s.offset_ns);
+        std::sort(offsets.begin(), offsets.end());
+
+        // Strip isolated upward outliers (same gap logic as probes).
+        size_t top = offsets.size();
+        while (top > 1) {
+            if (offsets[top - 1] - offsets[top - 2] > DATA_GAP_THRESHOLD_NS)
+                --top;
+            else
+                break;
         }
-        m_current_offset_ns = *m_data_floor_ns;
-        m_current_uncertainty_ns = ONE_WAY_DELAY_ESTIMATE_NS;
+
+        m_data_floor_ns = offsets[top - 1] + ONE_WAY_DELAY_ESTIMATE_NS;
     }
+
+    recomputeEstimate();
 }
 
 void ClockSync::recomputeEstimate() {
-    // If data-packet fallback has been activated, never revert to probes.
-    // Data timestamps (from the ADC/PTP clock) are always reliable, while
-    // probe timestamps (from header->time) may be broken on some firmware.
-    if (m_data_floor_ns.has_value())
-        return;
+    // Strategy:
+    //   1. If probes are reliable (tight spread), use glitch-filtered
+    //      max-offset probe.  This is the HUB1 path.
+    //   2. Otherwise, if data-packet samples are available, use the
+    //      glitch-filtered max raw_offset from data packets.  This is
+    //      the NSP path — data-packet timestamps (from the ADC/PTP
+    //      clock) are more stable than probe header->time on the NSP.
+    //   3. If neither is available, use probes anyway (unreliable but
+    //      better than nothing).
 
-    // Find probe with minimum RTT — least queuing/jitter gives most reliable estimate
-    const ProbeSample* best_probe = nullptr;
-    for (const auto& p : m_probe_samples) {
-        if (!best_probe || p.rtt_ns < best_probe->rtt_ns) {
-            best_probe = &p;
+    // Check if probes are reliable enough to use directly.
+    if (!m_probe_samples.empty() && probeSpreadOk()) {
+        // Probes are tight — use glitch-filtered max-offset.
+        std::vector<size_t> indices(m_probe_samples.size());
+        std::iota(indices.begin(), indices.end(), 0);
+        std::sort(indices.begin(), indices.end(),
+                  [this](size_t a, size_t b) {
+                      return m_probe_samples[a].offset_ns
+                           < m_probe_samples[b].offset_ns;
+                  });
+
+        constexpr int64_t GAP_THRESHOLD_NS = 10'000'000;  // 10 ms
+        size_t top = indices.size();
+        while (top > 1) {
+            if (m_probe_samples[indices[top - 1]].offset_ns -
+                m_probe_samples[indices[top - 2]].offset_ns > GAP_THRESHOLD_NS)
+                --top;
+            else
+                break;
         }
+
+        const auto& best = m_probe_samples[indices[top - 1]];
+        m_current_offset_ns = best.offset_ns;
+        m_current_uncertainty_ns = best.rtt_ns / 2;
+        return;
     }
 
-    if (best_probe) {
-        m_current_offset_ns = best_probe->offset_ns;
-        m_current_uncertainty_ns = best_probe->rtt_ns / 2;
-    } else if (m_data_samples.empty()) {
-        // Only clear if no data-packet fallback either
-        m_current_offset_ns = std::nullopt;
-        m_current_uncertainty_ns = std::nullopt;
+    // Probes unreliable or absent — use data-packet fallback.
+    if (m_data_floor_ns.has_value()) {
+        m_current_offset_ns = *m_data_floor_ns;
+        m_current_uncertainty_ns = 700'000;  // ONE_WAY_DELAY_ESTIMATE_NS
+        return;
     }
+
+    // Last resort: use probes even though they're unreliable.
+    if (!m_probe_samples.empty()) {
+        // Same glitch-filtered max-offset as above.
+        std::vector<size_t> indices(m_probe_samples.size());
+        std::iota(indices.begin(), indices.end(), 0);
+        std::sort(indices.begin(), indices.end(),
+                  [this](size_t a, size_t b) {
+                      return m_probe_samples[a].offset_ns
+                           < m_probe_samples[b].offset_ns;
+                  });
+
+        constexpr int64_t GAP_THRESHOLD_NS = 10'000'000;
+        size_t top = indices.size();
+        while (top > 1) {
+            if (m_probe_samples[indices[top - 1]].offset_ns -
+                m_probe_samples[indices[top - 2]].offset_ns > GAP_THRESHOLD_NS)
+                --top;
+            else
+                break;
+        }
+
+        const auto& best = m_probe_samples[indices[top - 1]];
+        m_current_offset_ns = best.offset_ns;
+        m_current_uncertainty_ns = best.rtt_ns / 2;
+        return;
+    }
+
+    m_current_offset_ns = std::nullopt;
+    m_current_uncertainty_ns = std::nullopt;
 }
 
 bool ClockSync::probeSpreadOk() const {

--- a/src/cbdev/src/device_session.cpp
+++ b/src/cbdev/src/device_session.cpp
@@ -1338,7 +1338,7 @@ void DeviceSession::updateConfigFromBuffer(const void* buffer, const size_t byte
     // Track the LAST data packet's timestamp in the datagram — it is
     // closest to the actual send time (earlier packets may be ~1 ms
     // stale from the start of the device's transmit batch).
-    const bool need_data_clock_sample = !m_impl->clock_sync.probesAreReliable();
+    const bool need_fallback_clock_sample = !m_impl->clock_sync.probesAreReliable();
     uint64_t last_data_time = 0;
 
     // Parse packets in buffer and update device_config for configuration packets
@@ -1361,7 +1361,7 @@ void DeviceSession::updateConfigFromBuffer(const void* buffer, const size_t byte
         // Track the last data packet timestamp for fallback clock sync.
         // Data timestamps come from the ADC/PTP clock and are reliable
         // even when probe header->time is broken.
-        if (need_data_clock_sample &&
+        if (need_fallback_clock_sample &&
             !(header->chid & cbPKTCHAN_CONFIGURATION) &&
             header->time != 0) {
             last_data_time = header->time;

--- a/src/cbdev/src/device_session.cpp
+++ b/src/cbdev/src/device_session.cpp
@@ -981,6 +981,12 @@ std::optional<int64_t> DeviceSession::getUncertaintyNs() const {
     return m_impl->clock_sync.getUncertaintyNs();
 }
 
+void DeviceSession::setExternalClockOffset(std::optional<int64_t> offset_ns,
+                                            std::optional<int64_t> uncertainty_ns) {
+    if (!m_impl) return;
+    m_impl->clock_sync.setExternalOffset(offset_ns, uncertainty_ns);
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Channel Configuration
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cbdev/src/device_session_impl.h
+++ b/src/cbdev/src/device_session_impl.h
@@ -310,6 +310,8 @@ public:
 
     [[nodiscard]] std::optional<int64_t> getOffsetNs() const override;
     [[nodiscard]] std::optional<int64_t> getUncertaintyNs() const override;
+    void setExternalClockOffset(std::optional<int64_t> offset_ns,
+                                std::optional<int64_t> uncertainty_ns = std::nullopt) override;
 
     /// @}
 

--- a/src/cbdev/src/device_session_wrapper.h
+++ b/src/cbdev/src/device_session_wrapper.h
@@ -230,6 +230,11 @@ public:
         return m_device.getUncertaintyNs();
     }
 
+    void setExternalClockOffset(std::optional<int64_t> offset_ns,
+                                std::optional<int64_t> uncertainty_ns = std::nullopt) override {
+        m_device.setExternalClockOffset(offset_ns, uncertainty_ns);
+    }
+
     /// @}
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/cbsdk/include/cbsdk/sdk_session.h
+++ b/src/cbsdk/include/cbsdk/sdk_session.h
@@ -714,12 +714,15 @@ public:
     Result<void> sendClockProbe();
 
     /// Current offset estimate: device_ns - steady_clock_ns.
+    /// On NSP devices with unreliable probes, may transparently read
+    /// a peer HUB's offset from shared memory when available.
     /// @return Offset in nanoseconds, or nullopt if no sync data available
     std::optional<int64_t> getClockOffsetNs() const;
 
-    /// Uncertainty (half-RTT) from best probe, or INT64_MAX for one-way only.
+    /// Uncertainty (half-RTT) from best probe, or ONE_WAY_DELAY_ESTIMATE for data fallback.
     /// @return Uncertainty in nanoseconds, or nullopt if no sync data available
     std::optional<int64_t> getClockUncertaintyNs() const;
+
 
     ///--------------------------------------------------------------------------------------------
     /// Packet Transmission

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -868,7 +868,7 @@ Result<void> SdkSession::start() {
 
                 // Periodic clock sync probing
                 auto now = std::chrono::steady_clock::now();
-                if (now - impl->last_clock_probe_time > std::chrono::seconds(2)) {
+                if (now - impl->last_clock_probe_time > std::chrono::milliseconds(100)) {
                     impl->device_session->sendClockProbe();
                     impl->last_clock_probe_time = now;
                 }

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -965,6 +965,31 @@ Result<void> SdkSession::start() {
                     impl->last_clock_probe_time = now;
                 }
 
+                // If this NSP is using data-packet fallback, try to inject
+                // a peer HUB's probe-based offset into the ClockSync so
+                // that toLocalTime() uses it on the hot path.
+                constexpr int64_t DATA_FALLBACK_UNCERT = 700'000;
+                auto own_uncert = impl->device_session->getUncertaintyNs();
+                if (own_uncert && *own_uncert == DATA_FALLBACK_UNCERT &&
+                    (impl->config.device_type == DeviceType::NSP ||
+                     impl->config.device_type == DeviceType::LEGACY_NSP)) {
+                    if (!impl->peer_clock_attempted) {
+                        impl->peer_clock_attempted = true;
+                        for (auto hub : {DeviceType::HUB1, DeviceType::HUB2, DeviceType::HUB3}) {
+                            std::string name = getNativeSegmentName(hub, "config");
+                            if (impl->peer_clock.tryOpen(name))
+                                break;
+                        }
+                    }
+                    auto peer_offset = impl->peer_clock.getClockOffsetNs();
+                    auto peer_uncert = impl->peer_clock.getClockUncertaintyNs();
+                    if (peer_offset) {
+                        impl->device_session->setExternalClockOffset(peer_offset, peer_uncert);
+                    } else {
+                        impl->device_session->setExternalClockOffset(std::nullopt);
+                    }
+                }
+
                 // Propagate clock sync offset to shmem for CLIENT mode readers
                 if (auto offset = impl->device_session->getOffsetNs()) {
                     auto uncertainty = impl->device_session->getUncertaintyNs().value_or(0);
@@ -2230,33 +2255,12 @@ Result<void> SdkSession::sendClockProbe() {
 }
 
 std::optional<int64_t> SdkSession::getClockOffsetNs() const {
-    // STANDALONE: get from device_session's ClockSync
-    if (m_impl->device_session) {
-        auto offset = m_impl->device_session->getOffsetNs();
-        auto uncert = m_impl->device_session->getUncertaintyNs();
-
-        // If using data-packet fallback (uncertainty == 700 µs) and this
-        // is an NSP, try to read a peer HUB's probe-based offset from
-        // shared memory.  Both devices share the same PTP clock, so the
-        // HUB's offset is valid for the NSP too.
-        constexpr int64_t DATA_FALLBACK_UNCERT = 700'000;
-        if (uncert && *uncert == DATA_FALLBACK_UNCERT &&
-            (m_impl->config.device_type == DeviceType::NSP ||
-             m_impl->config.device_type == DeviceType::LEGACY_NSP)) {
-            if (!m_impl->peer_clock_attempted) {
-                m_impl->peer_clock_attempted = true;
-                for (auto hub : {DeviceType::HUB1, DeviceType::HUB2, DeviceType::HUB3}) {
-                    std::string name = getNativeSegmentName(hub, "config");
-                    if (m_impl->peer_clock.tryOpen(name))
-                        break;
-                }
-            }
-            if (auto peer = m_impl->peer_clock.getClockOffsetNs())
-                return peer;
-        }
-
-        return offset;
-    }
+    // STANDALONE: get from device_session's ClockSync.
+    // The peer HUB offset (if active) is already injected into the
+    // ClockSync via setExternalOffset() in the periodic update, so
+    // this returns the peer's value transparently.
+    if (m_impl->device_session)
+        return m_impl->device_session->getOffsetNs();
 
     // CLIENT: try shmem clock sync fields (NATIVE layout)
     if (m_impl->shmem_session) {
@@ -2270,20 +2274,8 @@ std::optional<int64_t> SdkSession::getClockOffsetNs() const {
 }
 
 std::optional<int64_t> SdkSession::getClockUncertaintyNs() const {
-    // STANDALONE: get from device_session's ClockSync
-    if (m_impl->device_session) {
-        auto uncert = m_impl->device_session->getUncertaintyNs();
-
-        // If using data fallback and peer clock is active, report the
-        // peer's (lower) uncertainty instead.
-        constexpr int64_t DATA_FALLBACK_UNCERT = 700'000;
-        if (uncert && *uncert == DATA_FALLBACK_UNCERT && m_impl->peer_clock.isOpen()) {
-            if (auto peer_uncert = m_impl->peer_clock.getClockUncertaintyNs())
-                return peer_uncert;
-        }
-
-        return uncert;
-    }
+    if (m_impl->device_session)
+        return m_impl->device_session->getUncertaintyNs();
 
     // CLIENT: try shmem clock sync fields (NATIVE layout)
     if (m_impl->shmem_session) {

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -32,6 +32,13 @@
 #include <array>
 #include <vector>
 #include "cbdev/clock_sync.h"
+#ifndef _WIN32
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <unistd.h>
+#endif
 
 namespace {
 
@@ -58,6 +65,85 @@ inline void hr_sleep_us([[maybe_unused]] uint64_t microseconds) {
     std::this_thread::sleep_for(std::chrono::microseconds(static_cast<int64_t>(microseconds)));
 #endif
 }
+
+/// Lightweight read-only reader for a peer device's clock sync fields
+/// in shared memory.  Opens only the config segment via shm_open/mmap
+/// (not a full ShmemSession).  Used by the NSP to borrow a HUB's
+/// probe-based clock offset when its own probes are unreliable.
+struct PeerClockReader {
+#ifndef _WIN32
+    int fd = -1;
+    void* mapped = nullptr;
+    size_t mapped_size = 0;
+
+    bool isOpen() const { return mapped != nullptr && mapped != MAP_FAILED; }
+
+    bool tryOpen(const std::string& segment_name) {
+        close();
+        std::string posix_name = "/" + segment_name;
+        fd = shm_open(posix_name.c_str(), O_RDONLY, 0);
+        if (fd < 0)
+            return false;
+        struct stat st{};
+        if (fstat(fd, &st) < 0 || st.st_size < static_cast<off_t>(sizeof(cbshm::NativeConfigBuffer))) {
+            ::close(fd);
+            fd = -1;
+            return false;
+        }
+        mapped_size = static_cast<size_t>(st.st_size);
+        mapped = mmap(nullptr, mapped_size, PROT_READ, MAP_SHARED, fd, 0);
+        if (mapped == MAP_FAILED) {
+            mapped = nullptr;
+            ::close(fd);
+            fd = -1;
+            return false;
+        }
+        return true;
+    }
+
+    std::optional<int64_t> getClockOffsetNs() const {
+        if (!isOpen()) return std::nullopt;
+        const auto* cfg = static_cast<const cbshm::NativeConfigBuffer*>(mapped);
+        if (!cfg->clock_sync_valid) return std::nullopt;
+        // Liveness check: is the owning process still alive?
+        if (cfg->owner_pid != 0 && kill(static_cast<pid_t>(cfg->owner_pid), 0) != 0)
+            return std::nullopt;
+        return cfg->clock_offset_ns;
+    }
+
+    std::optional<int64_t> getClockUncertaintyNs() const {
+        if (!isOpen()) return std::nullopt;
+        const auto* cfg = static_cast<const cbshm::NativeConfigBuffer*>(mapped);
+        if (!cfg->clock_sync_valid) return std::nullopt;
+        if (cfg->owner_pid != 0 && kill(static_cast<pid_t>(cfg->owner_pid), 0) != 0)
+            return std::nullopt;
+        return cfg->clock_uncertainty_ns;
+    }
+
+    void close() {
+        if (mapped && mapped != MAP_FAILED)
+            munmap(mapped, mapped_size);
+        mapped = nullptr;
+        mapped_size = 0;
+        if (fd >= 0)
+            ::close(fd);
+        fd = -1;
+    }
+
+    ~PeerClockReader() { close(); }
+#else
+    // Windows stub — not yet implemented
+    bool isOpen() const { return false; }
+    bool tryOpen(const std::string&) { return false; }
+    std::optional<int64_t> getClockOffsetNs() const { return std::nullopt; }
+    std::optional<int64_t> getClockUncertaintyNs() const { return std::nullopt; }
+    void close() {}
+#endif
+
+    PeerClockReader() = default;
+    PeerClockReader(const PeerClockReader&) = delete;
+    PeerClockReader& operator=(const PeerClockReader&) = delete;
+};
 
 } // anonymous namespace
 
@@ -192,6 +278,12 @@ struct SdkSession::Impl {
 
     // CLIENT-mode clock sync (used when no device_session is available)
     cbdev::ClockSync client_clock_sync;
+
+    // Peer-device clock sync reader.  When this device (NSP) has
+    // unreliable probes, we try to read a peer HUB's clock offset
+    // from its shared memory config segment instead.
+    PeerClockReader peer_clock;
+    bool peer_clock_attempted = false;  // only try once
     struct PendingClockProbe {
         std::chrono::steady_clock::time_point t1_local;
         bool active = false;
@@ -2139,8 +2231,32 @@ Result<void> SdkSession::sendClockProbe() {
 
 std::optional<int64_t> SdkSession::getClockOffsetNs() const {
     // STANDALONE: get from device_session's ClockSync
-    if (m_impl->device_session)
-        return m_impl->device_session->getOffsetNs();
+    if (m_impl->device_session) {
+        auto offset = m_impl->device_session->getOffsetNs();
+        auto uncert = m_impl->device_session->getUncertaintyNs();
+
+        // If using data-packet fallback (uncertainty == 700 µs) and this
+        // is an NSP, try to read a peer HUB's probe-based offset from
+        // shared memory.  Both devices share the same PTP clock, so the
+        // HUB's offset is valid for the NSP too.
+        constexpr int64_t DATA_FALLBACK_UNCERT = 700'000;
+        if (uncert && *uncert == DATA_FALLBACK_UNCERT &&
+            (m_impl->config.device_type == DeviceType::NSP ||
+             m_impl->config.device_type == DeviceType::LEGACY_NSP)) {
+            if (!m_impl->peer_clock_attempted) {
+                m_impl->peer_clock_attempted = true;
+                for (auto hub : {DeviceType::HUB1, DeviceType::HUB2, DeviceType::HUB3}) {
+                    std::string name = getNativeSegmentName(hub, "config");
+                    if (m_impl->peer_clock.tryOpen(name))
+                        break;
+                }
+            }
+            if (auto peer = m_impl->peer_clock.getClockOffsetNs())
+                return peer;
+        }
+
+        return offset;
+    }
 
     // CLIENT: try shmem clock sync fields (NATIVE layout)
     if (m_impl->shmem_session) {
@@ -2155,8 +2271,19 @@ std::optional<int64_t> SdkSession::getClockOffsetNs() const {
 
 std::optional<int64_t> SdkSession::getClockUncertaintyNs() const {
     // STANDALONE: get from device_session's ClockSync
-    if (m_impl->device_session)
-        return m_impl->device_session->getUncertaintyNs();
+    if (m_impl->device_session) {
+        auto uncert = m_impl->device_session->getUncertaintyNs();
+
+        // If using data fallback and peer clock is active, report the
+        // peer's (lower) uncertainty instead.
+        constexpr int64_t DATA_FALLBACK_UNCERT = 700'000;
+        if (uncert && *uncert == DATA_FALLBACK_UNCERT && m_impl->peer_clock.isOpen()) {
+            if (auto peer_uncert = m_impl->peer_clock.getClockUncertaintyNs())
+                return peer_uncert;
+        }
+
+        return uncert;
+    }
 
     // CLIENT: try shmem clock sync fields (NATIVE layout)
     if (m_impl->shmem_session) {

--- a/tests/unit/test_clock_sync.cpp
+++ b/tests/unit/test_clock_sync.cpp
@@ -147,47 +147,50 @@ TEST(ClockSyncTest, ProbeExpiry) {
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-// Best Probe Selection (minimum RTT)
+// Best Probe Selection (maximum offset)
+//
+// The algorithm selects the probe with the largest computed offset (after gap-based glitch
+// rejection). For symmetric network paths this is equivalent to minimum RTT: the probe with the
+// least processing delay has the largest offset estimate. For asymmetric paths, max-offset is
+// the correct criterion because a higher offset means less queuing/processing bias in T3.
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-TEST(ClockSyncTest, MinRTTSelection) {
+TEST(ClockSyncTest, MaxOffsetSelection) {
     ClockSync sync;
 
-    // Probe 1: RTT = 1000 (worse)
+    // Probe 1: RTT = 1000, offset = 5000 — higher offset, should be selected
     // T1 = 1000, T3 = 6500, T4 = 2000
     // offset = 6500 - 1000 - 0.5 * 1000 = 5000
     sync.addProbeSample(tp_from_ns(1000), 6500, tp_from_ns(2000));
     EXPECT_EQ(*sync.getOffsetNs(), 5000);
 
-    // Probe 2: RTT = 200 (better — should be selected)
+    // Probe 2: RTT = 200, offset = 4900 — lower RTT but also lower offset, not selected
     // T1 = 3000, T3 = 8000, T4 = 3200
     // offset = 8000 - 3000 - 0.5 * 200 = 4900
     sync.addProbeSample(tp_from_ns(3000), 8000, tp_from_ns(3200));
 
-    // Best probe is probe 2 (lowest RTT)
-    EXPECT_EQ(*sync.getOffsetNs(), 4900);
-    EXPECT_EQ(*sync.getUncertaintyNs(), 100);
+    // Best probe is probe 1 (highest offset), not probe 2 (lowest RTT)
+    EXPECT_EQ(*sync.getOffsetNs(), 5000);
+    EXPECT_EQ(*sync.getUncertaintyNs(), 500);
 }
 
-TEST(ClockSyncTest, BestProbeIsMinimumRTT) {
+TEST(ClockSyncTest, BestProbeIsMaxOffset) {
     ClockSync sync;
 
-    // Add 3 probes with different RTTs. The min-RTT probe should win
-    // regardless of insertion order.
+    // Add 3 probes. The max-offset probe should win regardless of insertion order.
+    // In this case the max-offset probe also happens to have the minimum RTT
+    // (consistent with symmetric-path assumptions).
 
-    // Probe A: RTT = 500
+    // Probe A: RTT = 500, offset = 9750
     sync.addProbeSample(tp_from_ns(0), 10000, tp_from_ns(500));
-    // offset = 10000 - 0 - 0.5 * 500 = 9750
 
-    // Probe B: RTT = 100 (best)
+    // Probe B: RTT = 100, offset = 9950  (max offset — should be selected)
     sync.addProbeSample(tp_from_ns(1000), 11000, tp_from_ns(1100));
-    // offset = 11000 - 1000 - 0.5 * 100 = 9950
 
-    // Probe C: RTT = 300
+    // Probe C: RTT = 300, offset = 9850
     sync.addProbeSample(tp_from_ns(2000), 12000, tp_from_ns(2300));
-    // offset = 12000 - 2000 - 0.5 * 300 = 9850
 
-    // Probe B should be selected (RTT = 100)
+    // Probe B should be selected (highest offset = 9950)
     EXPECT_EQ(*sync.getOffsetNs(), 9950);
     EXPECT_EQ(*sync.getUncertaintyNs(), 50);  // RTT/2 = 100/2 = 50
 }


### PR DESCRIPTION
## Problem

When running an NSP and HUB simultaneously, events recorded by the NSP appeared ~10-15 ms later than the same events on the HUB after device_to_monotonic conversion. The root cause was the NSP's unreliable header->time (runs ~4% slow in 2-second cycles, with occasional large glitches), which caused the clock sync to fall back to a data-packet method that converged slowly and was vulnerable to permanent corruption from a single bad timestamp.
 
## Investigation

Using a new dual-device latency test (audio tone played to both devices simultaneously), we isolated the problem layer by layer: 

- PTP clocks are fine: Both devices agree on event timestamps to within ~0.9 ms in the PTP domain.
- device_to_monotonic introduces the bias: The NSP's clock offset estimate was systematically too low, shifting its converted timestamps into the future relative to the HUB.
- Two different methods disagreed: The HUB used probe-based sync (accurate, 0.2 ms uncertainty) while the NSP fell back to data-packet sync (biased by ~15 ms due to packet batching delay, and vulnerable to glitch-induced floor crashes of 500+ ms).
 
## Changes
 
Clock sync algorithm (clock_sync.cpp, clock_sync.h):
- Probe selection: max-offset with gap-based glitch rejection instead of min-RTT. Strips isolated upward outliers (>10 ms gap from neighbors) while selecting the highest-quality probes. Equivalent to min-RTT on devices with reliable timestamps (HUB).
- Data-packet fallback: max(raw_offset) instead of min. The maximum corresponds to the minimum one-way delay, which is closest to the true offset. Same gap-based glitch rejection. Recomputed from sliding window each update — no permanent monotonic floor.
- setExternalOffset(): new method to inject a peer device's offset directly, overriding internal estimates. Used by the peer shmem reader.
 
Probe infrastructure (sdk_session.cpp, clock_sync.h):
- Probe rate increased from 0.5 Hz to 10 Hz for better sampling of the NSP's 2-second processing cycles.
- Probe buffer increased from 8 to 80 samples (still ~8 seconds of history).
 
Peer HUB clock sharing (sdk_session.cpp):
- When the NSP falls back to data-packet sync, it opens the HUB1/2/3's shared memory config segment read-only via shm_open/mmap and reads the HUB's probe-based clock_offset_ns.
- The peer offset is injected into the NSP's ClockSync via setExternalOffset() in the periodic datagram callback (~every 10 ms), so toLocalTime() on the C++ hot path has zero additional overhead.
- Liveness check via kill(owner_pid, 0) prevents reading stale segments from dead processes.
- POSIX-only implementation (Windows stub returns nullopt).
 
Test script (analog_latency_test.py):
- Supports --device-type BOTH to run NSP and HUB simultaneously.
- Auto-calibrates detection thresholds per device using a calibration tone.
- Reports both PTP-domain and monotonic-domain cross-device deltas.
- Clock sync timeline monitor showing probe/data transitions and offset evolution.