### PR TITLE
Detect superseded shmem segments via per-creation segment_uid

### DIFF
--- a/src/cbshm/include/cbshm/native_types.h
+++ b/src/cbshm/include/cbshm/native_types.h
@@ -119,6 +119,12 @@ typedef struct {
 
     // Ownership tracking (written by STANDALONE at creation, read by CLIENT for liveness check)
     uint32_t owner_pid;             ///< PID of STANDALONE process that created this segment (0 = unknown)
+    uint32_t owner_reserved;        ///< Reserved (keeps segment_uid 8-byte aligned)
+    uint64_t segment_uid;           ///< Per-creation id of this segment instance (0 = unknown).
+                                    ///< Changes every time the owner unlinks + recreates the segment
+                                    ///< under the same name, so a CLIENT can detect that the segment it
+                                    ///< mapped has been superseded — something owner_pid cannot see when a
+                                    ///< persistent service (constant PID) tears down and recreates sessions.
 
     // This device's OWN (pre-consensus) offset estimate, written for peer
     // cross-device consensus voting.  Distinct from clock_offset_ns, which is

--- a/src/cbshm/include/cbshm/shmem_session.h
+++ b/src/cbshm/include/cbshm/shmem_session.h
@@ -273,13 +273,21 @@ public:
     /// @return uncertainty in nanoseconds, or nullopt if no sync data
     std::optional<int64_t> getClockUncertaintyNs() const;
 
-    /// @brief Check if the STANDALONE owner of these segments is still alive
+    /// @brief Check whether the segments this CLIENT mapped are still live and current
     ///
-    /// For NATIVE CLIENT mode, reads owner_pid from the config buffer and checks
-    /// if that process still exists. Returns true in all other cases (STANDALONE mode,
-    /// non-NATIVE layout, or unknown PID).
+    /// For NATIVE CLIENT mode, applies two checks against the config buffer:
+    ///  - Supersession: compares the per-creation @c segment_uid in our mapped
+    ///    buffer against the uid of whatever the segment name resolves to now.
+    ///    A mismatch (or a missing name) means the owner unlinked our segment and
+    ///    created a fresh one under the same name — undetectable via @c owner_pid
+    ///    when a persistent service keeps the same PID across sessions.
+    ///  - Crash-orphan: probes @c owner_pid to catch an owner that died without
+    ///    unlinking (segment_uid is unchanged in that case).
     ///
-    /// @return false if the owner process is confirmed dead (stale segments), true otherwise
+    /// Returns true in all other cases (STANDALONE mode, non-NATIVE layout, or an
+    /// unknown/zero uid and PID).
+    ///
+    /// @return false if the segments are stale (superseded or owner dead), true otherwise
     bool isOwnerAlive() const;
 
     /// @}

--- a/src/cbshm/src/shmem_session.cpp
+++ b/src/cbshm/src/shmem_session.cpp
@@ -231,6 +231,14 @@ struct ShmemSession::Impl {
     CentralVersion central_version;
     cbproto_protocol_version_t compat_protocol;
 
+    // NATIVE-layout segment identity captured at attach (0 = unknown).  Compared
+    // against the current named segment's uid in isOwnerAlive() to detect a
+    // segment that was recreated under the same name after we attached.  Must be
+    // a snapshot, not a live read of the buffer: on Windows a recreate reuses the
+    // same object and overwrites the uid in place, so a live read would always
+    // match itself.
+    uint64_t attached_segment_uid;
+
     // Typed accessor for config buffer
     NativeConfigBuffer* nativeCfg() {
         return static_cast<NativeConfigBuffer*>(cfg_buffer_raw);
@@ -277,6 +285,7 @@ struct ShmemSession::Impl {
         , rec_tailwrap(0)
         , central_version(CentralVersion::CURRENT)
         , compat_protocol(CBPROTO_PROTOCOL_CURRENT)
+        , attached_segment_uid(0)
     {}
 
     ~Impl() {
@@ -708,6 +717,13 @@ struct ShmemSession::Impl {
         }
 
         is_open = true;
+
+        // Snapshot the segment identity we attached to (STANDALONE has just
+        // written it in initBuffers(); CLIENT reads what the owner wrote).  Used
+        // by isOwnerAlive() to detect later supersession.
+        if (layout == ShmemLayout::NATIVE && cfg_buffer_raw) {
+            attached_segment_uid = nativeCfg()->segment_uid;
+        }
 
         // In CLIENT mode, sync our read position to the current head so we only
         // read NEW packets, not stale data that was already in the ring buffer.
@@ -2231,7 +2247,12 @@ bool ShmemSession::isOwnerAlive() const {
     // same PID across sessions, so owner_pid stays "alive" even after it has
     // torn down our segment and created a fresh one under the same name.  The
     // per-creation segment_uid distinguishes the instances.
-    uint64_t my_uid = m_impl->nativeCfg()->segment_uid;
+    //
+    // Compare the uid we captured at attach against the current named segment's
+    // uid.  We must use the captured snapshot, not a live read of our mapped
+    // buffer: on Windows a recreate reuses the same object and overwrites the
+    // uid in place, so a live-vs-current comparison would always match.
+    uint64_t my_uid = m_impl->attached_segment_uid;
     if (my_uid != 0) {
         std::optional<uint64_t> cur_uid = m_impl->readCurrentSegmentUid();
         if (!cur_uid.has_value() || *cur_uid != my_uid)

--- a/src/cbshm/src/shmem_session.cpp
+++ b/src/cbshm/src/shmem_session.cpp
@@ -43,6 +43,8 @@
 #include <cbshm/central_version.h>
 #include <cbshm/native_types.h>
 #include <cbproto/packet_translator.h>
+#include <atomic>
+#include <chrono>
 #include <memory>
 #include <cstring>
 #include <numeric>  // std::gcd
@@ -133,6 +135,28 @@ inline SegmentNames makeSegmentNames(ShmemLayout layout, const std::string& name
             "cbSIGNALevent" + suffix
         };
     }
+}
+
+// Generate a per-creation identifier for a shared-memory segment.  Written into
+// NativeConfigBuffer.segment_uid by the STANDALONE owner at creation so a CLIENT
+// can tell whether the segment it mapped is still the one the name resolves to.
+//
+// (POSIX inode would be the natural id, but macOS returns st_ino == 0 for shm
+// fds, so we mint a portable token instead: a high-resolution clock stamp mixed
+// with the PID and a process-local counter — distinct across recreations by the
+// same process and across processes.)
+inline uint64_t makeSegmentUid() {
+    static std::atomic<uint64_t> counter{0};
+    const uint64_t c = counter.fetch_add(1, std::memory_order_relaxed) + 1;
+    const uint64_t t = static_cast<uint64_t>(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+#ifdef _WIN32
+    const uint64_t pid = static_cast<uint64_t>(GetCurrentProcessId());
+#else
+    const uint64_t pid = static_cast<uint64_t>(getpid());
+#endif
+    uint64_t uid = t ^ (pid * 0x9E3779B97F4A7C15ull) ^ (c * 0xD1B54A32D192ED03ull);
+    return uid ? uid : 1;  // never 0 (0 means "unknown")
 }
 
 } // namespace
@@ -613,11 +637,15 @@ struct ShmemSession::Impl {
             std::memset(cfg, 0, cfg_buffer_size);
             cfg->version = cbVERSION_MAJOR * 100 + cbVERSION_MINOR;
             cfg->instrument_status = static_cast<uint32_t>(InstrumentStatus::INACTIVE);
+            // Ownership + per-creation identity.  owner_pid detects a crashed owner;
+            // segment_uid detects a live owner that recreated this segment under the
+            // same name (a persistent service keeps its PID, so only the uid changes).
 #ifdef _WIN32
             cfg->owner_pid = GetCurrentProcessId();
 #else
             cfg->owner_pid = static_cast<uint32_t>(getpid());
 #endif
+            cfg->segment_uid = makeSegmentUid();
 
             // Initialize receive buffer
             std::memset(rec_buffer_raw, 0, rec_buffer_size);
@@ -804,6 +832,46 @@ struct ShmemSession::Impl {
             return 30000; // default
         }
         return sysinfo.sysfreq;
+    }
+
+    /// @brief Read the segment_uid of whatever the config-buffer name resolves to
+    ///        right now (a fresh open, independent of our existing mapping).
+    ///
+    /// Returns nullopt if the name no longer exists (owner unlinked it).  Compared
+    /// by isOwnerAlive() against the uid stored in our mapped buffer to detect a
+    /// segment that has been superseded since we attached.
+    std::optional<uint64_t> readCurrentSegmentUid() const {
+#ifdef _WIN32
+        HANDLE h = OpenFileMappingA(FILE_MAP_READ, FALSE, cfg_name.c_str());
+        if (!h) {
+            return std::nullopt;  // Name gone => segment was destroyed
+        }
+        void* p = MapViewOfFile(h, FILE_MAP_READ, 0, 0, cfg_buffer_size);
+        if (!p) {
+            CloseHandle(h);
+            return std::nullopt;
+        }
+        uint64_t uid = static_cast<const NativeConfigBuffer*>(p)->segment_uid;
+        UnmapViewOfFile(p);
+        CloseHandle(h);
+        return uid;
+#else
+        std::string posix_name = (cfg_name[0] == '/') ? cfg_name : ("/" + cfg_name);
+        int fd = shm_open(posix_name.c_str(), O_RDONLY, 0);
+        if (fd < 0) {
+            return std::nullopt;  // Name gone => segment was destroyed
+        }
+        // macOS returns st_ino == 0 for shm fds, so we can't use the inode as the
+        // id — map the current segment and read the uid the owner stamped in.
+        void* p = mmap(nullptr, cfg_buffer_size, PROT_READ, MAP_SHARED, fd, 0);
+        ::close(fd);
+        if (p == MAP_FAILED) {
+            return std::nullopt;
+        }
+        uint64_t uid = static_cast<const NativeConfigBuffer*>(p)->segment_uid;
+        munmap(p, cfg_buffer_size);
+        return uid;
+#endif
     }
 };
 
@@ -2158,6 +2226,21 @@ bool ShmemSession::isOwnerAlive() const {
     if (m_impl->layout != ShmemLayout::NATIVE)
         return true;
 
+    // Supersession check: is the segment we mapped still the one this name
+    // resolves to?  A persistent owner (e.g. a long-running service) keeps the
+    // same PID across sessions, so owner_pid stays "alive" even after it has
+    // torn down our segment and created a fresh one under the same name.  The
+    // per-creation segment_uid distinguishes the instances.
+    uint64_t my_uid = m_impl->nativeCfg()->segment_uid;
+    if (my_uid != 0) {
+        std::optional<uint64_t> cur_uid = m_impl->readCurrentSegmentUid();
+        if (!cur_uid.has_value() || *cur_uid != my_uid)
+            return false;  // Name unlinked, or replaced by a newer segment — stale
+    }
+
+    // Crash-orphan check: the owner may have died without unlinking, leaving the
+    // same segment behind.  segment_uid can't see that (inode is unchanged), so
+    // fall back to probing the recorded PID.
     uint32_t pid = m_impl->nativeCfg()->owner_pid;
     if (pid == 0)
         return true;  // Pre-liveness segments or unknown — assume alive

--- a/tests/unit/test_shmem_session.cpp
+++ b/tests/unit/test_shmem_session.cpp
@@ -1641,6 +1641,82 @@ TEST_F(OwnerLivenessTest, ClientDetectsDeadOwner) {
     EXPECT_FALSE(client.value().isOwnerAlive());
 }
 
+TEST_F(OwnerLivenessTest, StandaloneWritesSegmentUid) {
+    auto result = ShmemSession::create(
+        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
+        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
+        test_name + "_signal", Mode::STANDALONE, ShmemLayout::NATIVE);
+    ASSERT_TRUE(result.isOk()) << result.error();
+
+    auto* cfg = result.value().getNativeConfigBuffer();
+    ASSERT_NE(cfg, nullptr);
+    EXPECT_NE(cfg->segment_uid, 0ull);
+}
+
+TEST_F(OwnerLivenessTest, ClientDetectsUnlinkedSegment) {
+    // Owner creates the segment; client attaches (records uid N1).
+    auto standalone = ShmemSession::create(
+        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
+        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
+        test_name + "_signal", Mode::STANDALONE, ShmemLayout::NATIVE);
+    ASSERT_TRUE(standalone.isOk()) << standalone.error();
+
+    auto client = ShmemSession::create(
+        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
+        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
+        test_name + "_signal", Mode::CLIENT, ShmemLayout::NATIVE);
+    ASSERT_TRUE(client.isOk()) << client.error();
+    EXPECT_TRUE(client.value().isOwnerAlive());  // segment is current
+
+    // Owner tears down the segment (unlinks the names); the client keeps its
+    // mapping.  With the name gone, the client's segment is stale.
+    {
+        ShmemSession owner = std::move(standalone.value());
+        // owner's destructor at end of scope runs close() -> shm_unlink.
+    }
+    EXPECT_FALSE(client.value().isOwnerAlive());
+}
+
+TEST_F(OwnerLivenessTest, ClientDetectsSupersededSegment) {
+    // Owner creates the segment (uid N1); client attaches.
+    auto standalone1 = ShmemSession::create(
+        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
+        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
+        test_name + "_signal", Mode::STANDALONE, ShmemLayout::NATIVE);
+    ASSERT_TRUE(standalone1.isOk()) << standalone1.error();
+
+    auto client = ShmemSession::create(
+        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
+        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
+        test_name + "_signal", Mode::CLIENT, ShmemLayout::NATIVE);
+    ASSERT_TRUE(client.isOk()) << client.error();
+    EXPECT_TRUE(client.value().isOwnerAlive());
+
+    // Owner tears the segment down, then a NEW owner recreates it under the SAME
+    // name (fresh uid N2).  This is the persistent-service case: owner_pid is
+    // identical, but the segment instance is different.
+    {
+        ShmemSession owner1 = std::move(standalone1.value());
+    }
+    auto standalone2 = ShmemSession::create(
+        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
+        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
+        test_name + "_signal", Mode::STANDALONE, ShmemLayout::NATIVE);
+    ASSERT_TRUE(standalone2.isOk()) << standalone2.error();
+
+    // A fresh client on the new segment sees it as current...
+    auto client2 = ShmemSession::create(
+        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
+        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
+        test_name + "_signal", Mode::CLIENT, ShmemLayout::NATIVE);
+    ASSERT_TRUE(client2.isOk()) << client2.error();
+    EXPECT_TRUE(client2.value().isOwnerAlive());
+
+    // ...but the old client, still mapped to the superseded segment, is stale —
+    // even though a live owner now holds the name (owner_pid alone can't tell).
+    EXPECT_FALSE(client.value().isOwnerAlive());
+}
+
 TEST_F(OwnerLivenessTest, ClientTreatsZeroPidAsAlive) {
     // Create STANDALONE, then clear owner_pid to simulate pre-liveness segments
     auto standalone = ShmemSession::create(Mode::STANDALONE, ShmemLayout::NATIVE, test_name, cbproto::InstrumentId::fromOneBased(cbNSP1));

--- a/tests/unit/test_shmem_session.cpp
+++ b/tests/unit/test_shmem_session.cpp
@@ -1642,10 +1642,8 @@ TEST_F(OwnerLivenessTest, ClientDetectsDeadOwner) {
 }
 
 TEST_F(OwnerLivenessTest, StandaloneWritesSegmentUid) {
-    auto result = ShmemSession::create(
-        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
-        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
-        test_name + "_signal", Mode::STANDALONE, ShmemLayout::NATIVE);
+    auto result = ShmemSession::create(Mode::STANDALONE, ShmemLayout::NATIVE, test_name,
+                                           cbproto::InstrumentId::fromOneBased(cbNSP1));
     ASSERT_TRUE(result.isOk()) << result.error();
 
     auto* cfg = result.value().getNativeConfigBuffer();
@@ -1653,18 +1651,22 @@ TEST_F(OwnerLivenessTest, StandaloneWritesSegmentUid) {
     EXPECT_NE(cfg->segment_uid, 0ull);
 }
 
+#ifndef _WIN32
+// POSIX-only: an owner "unlinking" its segment removes the name immediately
+// (shm_unlink), so a client's fresh open by name fails.  Windows has no unlink —
+// a named mapping persists as long as any handle is open, so an owner that
+// merely closes (without recreating) leaves the name and memory intact and the
+// client legitimately still sees a current segment.  That case is covered by
+// the crash-orphan (owner_pid) path or, mid-stream, by the client noticing the
+// data stall (see the pycbsdk liveness follow-up).
 TEST_F(OwnerLivenessTest, ClientDetectsUnlinkedSegment) {
     // Owner creates the segment; client attaches (records uid N1).
-    auto standalone = ShmemSession::create(
-        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
-        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
-        test_name + "_signal", Mode::STANDALONE, ShmemLayout::NATIVE);
+    auto standalone = ShmemSession::create(Mode::STANDALONE, ShmemLayout::NATIVE, test_name,
+                                           cbproto::InstrumentId::fromOneBased(cbNSP1));
     ASSERT_TRUE(standalone.isOk()) << standalone.error();
 
-    auto client = ShmemSession::create(
-        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
-        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
-        test_name + "_signal", Mode::CLIENT, ShmemLayout::NATIVE);
+    auto client = ShmemSession::create(Mode::CLIENT, ShmemLayout::NATIVE, test_name,
+                                           cbproto::InstrumentId::fromOneBased(cbNSP1));
     ASSERT_TRUE(client.isOk()) << client.error();
     EXPECT_TRUE(client.value().isOwnerAlive());  // segment is current
 
@@ -1676,19 +1678,16 @@ TEST_F(OwnerLivenessTest, ClientDetectsUnlinkedSegment) {
     }
     EXPECT_FALSE(client.value().isOwnerAlive());
 }
+#endif  // !_WIN32
 
 TEST_F(OwnerLivenessTest, ClientDetectsSupersededSegment) {
     // Owner creates the segment (uid N1); client attaches.
-    auto standalone1 = ShmemSession::create(
-        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
-        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
-        test_name + "_signal", Mode::STANDALONE, ShmemLayout::NATIVE);
+    auto standalone1 = ShmemSession::create(Mode::STANDALONE, ShmemLayout::NATIVE, test_name,
+                                           cbproto::InstrumentId::fromOneBased(cbNSP1));
     ASSERT_TRUE(standalone1.isOk()) << standalone1.error();
 
-    auto client = ShmemSession::create(
-        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
-        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
-        test_name + "_signal", Mode::CLIENT, ShmemLayout::NATIVE);
+    auto client = ShmemSession::create(Mode::CLIENT, ShmemLayout::NATIVE, test_name,
+                                           cbproto::InstrumentId::fromOneBased(cbNSP1));
     ASSERT_TRUE(client.isOk()) << client.error();
     EXPECT_TRUE(client.value().isOwnerAlive());
 
@@ -1698,17 +1697,13 @@ TEST_F(OwnerLivenessTest, ClientDetectsSupersededSegment) {
     {
         ShmemSession owner1 = std::move(standalone1.value());
     }
-    auto standalone2 = ShmemSession::create(
-        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
-        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
-        test_name + "_signal", Mode::STANDALONE, ShmemLayout::NATIVE);
+    auto standalone2 = ShmemSession::create(Mode::STANDALONE, ShmemLayout::NATIVE, test_name,
+                                           cbproto::InstrumentId::fromOneBased(cbNSP1));
     ASSERT_TRUE(standalone2.isOk()) << standalone2.error();
 
     // A fresh client on the new segment sees it as current...
-    auto client2 = ShmemSession::create(
-        test_name + "_cfg", test_name + "_rec", test_name + "_xmt",
-        test_name + "_xmt_local", test_name + "_status", test_name + "_spk",
-        test_name + "_signal", Mode::CLIENT, ShmemLayout::NATIVE);
+    auto client2 = ShmemSession::create(Mode::CLIENT, ShmemLayout::NATIVE, test_name,
+                                           cbproto::InstrumentId::fromOneBased(cbNSP1));
     ASSERT_TRUE(client2.isOk()) << client2.error();
     EXPECT_TRUE(client2.value().isOwnerAlive());
 


### PR DESCRIPTION
## Problem

`ShmemSession::isOwnerAlive()` rejected stale NATIVE CLIENT segments using only `owner_pid`. That check is blind when a **persistent service** owns the shared memory.

Concretely, Orion (`orion/src/device/CereLink.cpp`) is one long-lived process. Its `disconnect()` → `m_session.reset()` cleanly destroys the STANDALONE `ShmemSession` (running `shm_unlink`), and each `connect()` recreates the device's segments under the same name. Across every start/stop cycle `owner_pid` stays equal to Orion's PID, so `isOwnerAlive()` always reports "alive" — even for a segment that belongs to a session that was closed and superseded. A CLIENT holding the old mapping has no way to tell it is stale.

## Fix

Add a per-creation `segment_uid` to `NativeConfigBuffer`, stamped by the STANDALONE owner at creation. `isOwnerAlive()` now applies two checks:

| Failure mode | detected by |
|---|---|
| Persistent owner recreated the segment under the same name | `segment_uid` mismatch (new) |
| Owner crashed without unlinking | `owner_pid` dead (existing) |

Both are needed — the PID catches the crash-orphan case (uid unchanged), the uid catches supersession (pid unchanged). A zero `segment_uid` or `owner_pid` skips that check for backward compatibility with pre-liveness segments.

`readCurrentSegmentUid()` re-opens the segment name and reads the uid of whatever it resolves to *now*, comparing against the uid in our mapped buffer.

### Why a token, not an inode

The natural identity would be the segment inode, but **macOS returns `st_ino == 0` for POSIX shm fds** (verified), so inode is unusable there. `segment_uid` is a portable token: `steady_clock` stamp ^ pid ^ process-local atomic counter (never 0), stored in the buffer and read back by mapping the re-opened segment on both platforms.

## Out of scope

`isOwnerAlive()` is a **one-shot check at attach** (`sdk_session.cpp` ~814). A client that attaches to the current segment and is superseded *while streaming* won't notice until something re-checks. That periodic liveness poll belongs in the client (pycbsdk/sdk_session) and is intentionally deferred — tracked in a separate issue.

## Tests

New `OwnerLivenessTest` cases: `StandaloneWritesSegmentUid`, `ClientDetectsUnlinkedSegment`, `ClientDetectsSupersededSegment`. `cbshm_tests`: 104/104 pass; full project builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)