### PR TITLE
Address each instrument independently in CENTRAL CLIENT mode

### DIFF
--- a/pycbsdk/src/pycbsdk/_cdef.py
+++ b/pycbsdk/src/pycbsdk/_cdef.py
@@ -195,11 +195,13 @@ uint32_t cbsdk_session_get_runlevel(cbsdk_session_t session);
 int cbsdk_session_is_standalone(cbsdk_session_t session);
 uint32_t cbsdk_session_get_protocol_version(cbsdk_session_t session);
 uint32_t cbsdk_session_get_proc_ident(cbsdk_session_t session, char* buf, uint32_t buf_size);
+cbsdk_result_t cbsdk_session_get_proc_chan_range(cbsdk_session_t session, uint32_t* out_chanbase, uint32_t* out_chancount);
 uint32_t cbsdk_session_get_spike_length(cbsdk_session_t session);
 uint32_t cbsdk_session_get_spike_pretrigger(cbsdk_session_t session);
 cbsdk_result_t cbsdk_session_set_spike_length(cbsdk_session_t session,
     uint32_t spike_length, uint32_t spike_pretrigger);
 uint32_t cbsdk_get_max_chans(void);
+cbsdk_result_t cbsdk_session_get_max_chans(cbsdk_session_t session, uint32_t* out_max_chans);
 uint32_t cbsdk_get_num_fe_chans(void);
 uint32_t cbsdk_get_num_analog_chans(void);
 uint32_t cbsdk_session_get_channel_label_length(void);

--- a/pycbsdk/src/pycbsdk/session.py
+++ b/pycbsdk/src/pycbsdk/session.py
@@ -741,9 +741,20 @@ class Session:
             "Failed to set spike length",
         )
 
-    @staticmethod
-    def max_chans() -> int:
-        """Total number of channels (cbMAXCHANS)."""
+    def max_chans(self) -> int:
+        """Number of channels this device actually has.
+
+        Channel ids are local to the device in both STANDALONE and CLIENT
+        modes, so valid ids are ``1..max_chans()``.  A Gemini hub reports 256 —
+        it is front-end only, the physical I/O lives on the NSP — while a
+        legacy analog NSP reports its full complement including that I/O.
+
+        Falls back to the compile-time ``cbMAXCHANS`` only if the session is
+        not open.
+        """
+        out = ffi.new("uint32_t *")
+        if _get_lib().cbsdk_session_get_max_chans(self._session, out) == 0:
+            return out[0]
         return _get_lib().cbsdk_get_max_chans()
 
     @staticmethod

--- a/src/cbdev/include/cbdev/clock_sync.h
+++ b/src/cbdev/include/cbdev/clock_sync.h
@@ -149,6 +149,7 @@ private:
     };
     std::deque<DataSample> m_data_samples;
     std::optional<int64_t> m_data_floor_ns;  // monotonic floor for data fallback
+    std::optional<int64_t> m_data_spread_ns; // spread of the samples behind it
 
     std::optional<int64_t> m_current_offset_ns;
     std::optional<int64_t> m_current_uncertainty_ns;

--- a/src/cbdev/src/clock_sync.cpp
+++ b/src/cbdev/src/clock_sync.cpp
@@ -10,6 +10,9 @@
 #include "cbdev/clock_sync.h"
 #include <algorithm>
 #include <cmath>
+#include <cstdio>    // TEMPORARY for #198 diagnostics
+#include <cstdlib>   // TEMPORARY for #198 diagnostics
+#include <string>    // TEMPORARY for #198 diagnostics
 #include <numeric>
 #include <vector>
 
@@ -64,6 +67,17 @@ void ClockSync::addProbeSample(time_point t1_local, uint64_t t3_device_ns, time_
     sample.offset_ns = offset_ns;
     sample.rtt_ns = rtt_ns;
     sample.when = t4_local;
+
+    // TEMPORARY diagnostic for #198 — set CERELINK_CLOCK_DEBUG=1 to enable.
+    if (const char* dbg = std::getenv("CERELINK_CLOCK_DEBUG")) {
+        if (*dbg == '1') {
+            std::fprintf(stderr,
+                         "[clk] probe rtt=%.3fms offset=%lld t3=%llu n=%zu\n",
+                         rtt_ns / 1e6, static_cast<long long>(offset_ns),
+                         static_cast<unsigned long long>(t3_device_ns),
+                         m_probe_samples.size() + 1);
+        }
+    }
 
     m_probe_samples.push_back(sample);
 
@@ -226,9 +240,26 @@ ClockSync::InternalEstimate ClockSync::computeInternalEstimate() const {
         }
 
         const auto& best = m_probe_samples[indices[top - 1]];
+
+        // rtt/2 bounds the error only if the samples agree with each other.
+        // When they scatter, the disagreement is the real uncertainty: a
+        // device that transmits in blocks latches its reply timestamps to
+        // block boundaries, so every offset inherits that quantisation no
+        // matter how fast the round trip was. A Gemini NSP produced 187 ms of
+        // spread on 20 ms round trips -- reporting 10 ms there advertises
+        // millisecond confidence for an estimate wrong by a sixth of a second,
+        // and a caller checking the uncertainty has no way to tell.
+        //
+        // Spread is measured over the glitch-filtered set actually in play
+        // (indices[0..top-1]); half of it is a symmetric proxy for what is
+        // really a one-sided error, since taking the max offset picks the
+        // least-delayed sample and the true offset lies at or above it.
+        const int64_t spread_ns =
+            best.offset_ns - m_probe_samples[indices[0]].offset_ns;
+
         InternalEstimate e;
         e.offset_ns = best.offset_ns;
-        e.uncertainty_ns = best.rtt_ns / 2;
+        e.uncertainty_ns = std::max<int64_t>(best.rtt_ns / 2, spread_ns / 2);
         return e;
     };
 
@@ -241,18 +272,48 @@ ClockSync::InternalEstimate ClockSync::computeInternalEstimate() const {
     //      clock) are more stable than probe header->time on the NSP.
     //   3. If neither is available, use probes anyway (unreliable but
     //      better than nothing).
-    if (!m_probe_samples.empty() && probeSpreadOk())
-        return bestProbe();
+    // TEMPORARY diagnostic for #198 — set CERELINK_CLOCK_DEBUG=1 to enable.
+    const auto dbg = [this](const char* which, const InternalEstimate& e) {
+        const char* d = std::getenv("CERELINK_CLOCK_DEBUG");
+        if (!d || *d != '1') return;
+        int64_t lo = 0, hi = 0;
+        if (!m_probe_samples.empty()) {
+            lo = hi = m_probe_samples.front().offset_ns;
+            for (const auto& p : m_probe_samples) {
+                lo = std::min(lo, p.offset_ns);
+                hi = std::max(hi, p.offset_ns);
+            }
+        }
+        std::fprintf(stderr,
+                     "[clk] PICK=%s probes=%zu spread=%.3fms spreadOk=%d "
+                     "data=%zu floor=%s offset=%lld unc=%.3fms\n",
+                     which, m_probe_samples.size(), (hi - lo) / 1e6,
+                     m_probe_samples.empty() ? -1 : (int)probeSpreadOk(),
+                     m_data_samples.size(),
+                     m_data_floor_ns ? std::to_string(*m_data_floor_ns).c_str() : "none",
+                     e.offset_ns ? static_cast<long long>(*e.offset_ns) : 0LL,
+                     e.uncertainty_ns / 1e6);
+    };
+
+    if (!m_probe_samples.empty() && probeSpreadOk()) {
+        auto e = bestProbe();
+        dbg("probe-reliable", e);
+        return e;
+    }
 
     if (m_data_floor_ns.has_value()) {
         InternalEstimate e;
         e.offset_ns = *m_data_floor_ns;
         e.uncertainty_ns = 700'000;  // ONE_WAY_DELAY_ESTIMATE_NS
+        dbg("data-floor", e);
         return e;
     }
 
-    if (!m_probe_samples.empty())
-        return bestProbe();
+    if (!m_probe_samples.empty()) {
+        auto e = bestProbe();
+        dbg("probe-unreliable", e);
+        return e;
+    }
 
     return InternalEstimate{};  // offset_ns == nullopt
 }

--- a/src/cbdev/src/clock_sync.cpp
+++ b/src/cbdev/src/clock_sync.cpp
@@ -232,25 +232,38 @@ ClockSync::InternalEstimate ClockSync::computeInternalEstimate() const {
 
         const auto& best = m_probe_samples[indices[top - 1]];
 
-        // rtt/2 bounds the error only if the samples agree with each other.
-        // When they scatter, the disagreement is the real uncertainty: a
-        // device that transmits in blocks latches its reply timestamps to
-        // block boundaries, so every offset inherits that quantisation no
-        // matter how fast the round trip was. A Gemini NSP produced 187 ms of
-        // spread on 20 ms round trips -- reporting 10 ms there advertises
-        // millisecond confidence for an estimate wrong by a sixth of a second,
-        // and a caller checking the uncertainty has no way to tell.
+        // rtt/2 bounds the error only when transit delay is the sole error
+        // source. Offsets legitimately spread when round trips differ -- a
+        // slower probe yields a lower offset -- and picking the max already
+        // compensates for that, so charging the whole spread as uncertainty
+        // would double-count an effect that is handled.
         //
-        // Spread is measured over the glitch-filtered set actually in play
-        // (indices[0..top-1]); half of it is a symmetric proxy for what is
-        // really a one-sided error, since taking the max offset picks the
-        // least-delayed sample and the true offset lies at or above it.
+        // What rtt/2 cannot bound is spread the round trips do not explain. A
+        // device that transmits in blocks latches its reply timestamps to
+        // block boundaries, so every offset inherits that quantisation however
+        // fast the round trip was: a Gemini NSP produced 187 ms of spread on
+        // 20 ms round trips that varied by only ~10 ms. Reporting 10 ms there
+        // advertises millisecond confidence for an estimate wrong by a sixth
+        // of a second, and a caller checking the uncertainty cannot tell.
+        //
+        // So charge only the unexplained part. Differing round trips can
+        // account for at most (rtt_hi - rtt_lo) / 2 of spread; anything beyond
+        // that is a second error source. Halved for the same reason as above:
+        // the max-offset pick is the least-delayed sample, so the true offset
+        // lies at or above it and the error is one-sided.
         const int64_t spread_ns =
             best.offset_ns - m_probe_samples[indices[0]].offset_ns;
+        int64_t rtt_lo = INT64_MAX, rtt_hi = 0;
+        for (size_t k = 0; k < top; ++k) {
+            rtt_lo = std::min(rtt_lo, m_probe_samples[indices[k]].rtt_ns);
+            rtt_hi = std::max(rtt_hi, m_probe_samples[indices[k]].rtt_ns);
+        }
+        const int64_t explained_ns = (rtt_hi - rtt_lo) / 2;
+        const int64_t unexplained_ns = std::max<int64_t>(0, spread_ns - explained_ns);
 
         InternalEstimate e;
         e.offset_ns = best.offset_ns;
-        e.uncertainty_ns = std::max<int64_t>(best.rtt_ns / 2, spread_ns / 2);
+        e.uncertainty_ns = std::max<int64_t>(best.rtt_ns / 2, unexplained_ns / 2);
         return e;
     };
 

--- a/src/cbdev/src/clock_sync.cpp
+++ b/src/cbdev/src/clock_sync.cpp
@@ -95,6 +95,7 @@ void ClockSync::reset() {
     m_probe_samples.clear();
     m_data_samples.clear();
     m_data_floor_ns = std::nullopt;
+    m_data_spread_ns = std::nullopt;
     m_current_offset_ns = std::nullopt;
     m_current_uncertainty_ns = std::nullopt;
     resetDiscipline();
@@ -169,6 +170,7 @@ void ClockSync::addDataPacketSample(const uint64_t device_time_ns, const time_po
     if (m_current_offset_ns && std::abs(offset_ns - *m_current_offset_ns) > 1'000'000'000LL) {
         m_data_samples.clear();
         m_data_floor_ns = std::nullopt;
+        m_data_spread_ns = std::nullopt;
         m_current_offset_ns = std::nullopt;  // re-acquire immediately past a jump
         resetDiscipline();
     }
@@ -212,6 +214,9 @@ void ClockSync::addDataPacketSample(const uint64_t device_time_ns, const time_po
         }
 
         m_data_floor_ns = offsets[top - 1] + ONE_WAY_DELAY_ESTIMATE_NS;
+        // Spread of the glitch-filtered set, so the reported uncertainty can
+        // reflect how much the samples actually disagree instead of a constant.
+        m_data_spread_ns = offsets[top - 1] - offsets[0];
     }
 
     recomputeEstimate();
@@ -268,8 +273,13 @@ ClockSync::InternalEstimate ClockSync::computeInternalEstimate() const {
     //      glitch-filtered max-offset probe.  This is the HUB1 path.
     //   2. Otherwise, if data-packet samples are available, use the
     //      glitch-filtered max raw_offset from data packets.  This is
-    //      the NSP path — data-packet timestamps (from the ADC/PTP
-    //      clock) are more stable than probe header->time on the NSP.
+    //      the NSP path for a *device session* — data-packet timestamps
+    //      (from the ADC/PTP clock) are more stable than probe
+    //      header->time on the NSP, whose replies are latched to its
+    //      transmit blocks.  Only DeviceSession feeds addDataPacketSample,
+    //      so this branch is unreachable for the CLIENT-mode instance:
+    //      a NATIVE CLIENT inherits its owner's committed offset, and a
+    //      CENTRAL CLIENT derives one across instruments instead.
     //   3. If neither is available, use probes anyway (unreliable but
     //      better than nothing).
     // TEMPORARY diagnostic for #198 — set CERELINK_CLOCK_DEBUG=1 to enable.
@@ -304,7 +314,18 @@ ClockSync::InternalEstimate ClockSync::computeInternalEstimate() const {
     if (m_data_floor_ns.has_value()) {
         InternalEstimate e;
         e.offset_ns = *m_data_floor_ns;
-        e.uncertainty_ns = 700'000;  // ONE_WAY_DELAY_ESTIMATE_NS
+        // The floor takes the least-delayed sample seen, so its error is
+        // whatever delay that sample still carried -- unknowable directly, but
+        // the disagreement among samples is evidence for it. Reporting the flat
+        // ONE_WAY_DELAY_ESTIMATE_NS claimed 0.7 ms no matter how badly they
+        // scattered, the same way rtt/2 did on the probe path.
+        //
+        // Caveat: with only a handful of samples the spread understates the
+        // true uncertainty, since a narrow window is not evidence of a tight
+        // one. This floors at the old constant rather than pretending
+        // otherwise, but a sample-count term would be better still.
+        e.uncertainty_ns = std::max<int64_t>(700'000,  // ONE_WAY_DELAY_ESTIMATE_NS
+                                             m_data_spread_ns.value_or(0) / 2);
         dbg("data-floor", e);
         return e;
     }

--- a/src/cbdev/src/clock_sync.cpp
+++ b/src/cbdev/src/clock_sync.cpp
@@ -10,9 +10,6 @@
 #include "cbdev/clock_sync.h"
 #include <algorithm>
 #include <cmath>
-#include <cstdio>    // TEMPORARY for #198 diagnostics
-#include <cstdlib>   // TEMPORARY for #198 diagnostics
-#include <string>    // TEMPORARY for #198 diagnostics
 #include <numeric>
 #include <vector>
 
@@ -67,17 +64,6 @@ void ClockSync::addProbeSample(time_point t1_local, uint64_t t3_device_ns, time_
     sample.offset_ns = offset_ns;
     sample.rtt_ns = rtt_ns;
     sample.when = t4_local;
-
-    // TEMPORARY diagnostic for #198 — set CERELINK_CLOCK_DEBUG=1 to enable.
-    if (const char* dbg = std::getenv("CERELINK_CLOCK_DEBUG")) {
-        if (*dbg == '1') {
-            std::fprintf(stderr,
-                         "[clk] probe rtt=%.3fms offset=%lld t3=%llu n=%zu\n",
-                         rtt_ns / 1e6, static_cast<long long>(offset_ns),
-                         static_cast<unsigned long long>(t3_device_ns),
-                         m_probe_samples.size() + 1);
-        }
-    }
 
     m_probe_samples.push_back(sample);
 
@@ -282,34 +268,8 @@ ClockSync::InternalEstimate ClockSync::computeInternalEstimate() const {
     //      CENTRAL CLIENT derives one across instruments instead.
     //   3. If neither is available, use probes anyway (unreliable but
     //      better than nothing).
-    // TEMPORARY diagnostic for #198 — set CERELINK_CLOCK_DEBUG=1 to enable.
-    const auto dbg = [this](const char* which, const InternalEstimate& e) {
-        const char* d = std::getenv("CERELINK_CLOCK_DEBUG");
-        if (!d || *d != '1') return;
-        int64_t lo = 0, hi = 0;
-        if (!m_probe_samples.empty()) {
-            lo = hi = m_probe_samples.front().offset_ns;
-            for (const auto& p : m_probe_samples) {
-                lo = std::min(lo, p.offset_ns);
-                hi = std::max(hi, p.offset_ns);
-            }
-        }
-        std::fprintf(stderr,
-                     "[clk] PICK=%s probes=%zu spread=%.3fms spreadOk=%d "
-                     "data=%zu floor=%s offset=%lld unc=%.3fms\n",
-                     which, m_probe_samples.size(), (hi - lo) / 1e6,
-                     m_probe_samples.empty() ? -1 : (int)probeSpreadOk(),
-                     m_data_samples.size(),
-                     m_data_floor_ns ? std::to_string(*m_data_floor_ns).c_str() : "none",
-                     e.offset_ns ? static_cast<long long>(*e.offset_ns) : 0LL,
-                     e.uncertainty_ns / 1e6);
-    };
-
-    if (!m_probe_samples.empty() && probeSpreadOk()) {
-        auto e = bestProbe();
-        dbg("probe-reliable", e);
-        return e;
-    }
+    if (!m_probe_samples.empty() && probeSpreadOk())
+        return bestProbe();
 
     if (m_data_floor_ns.has_value()) {
         InternalEstimate e;
@@ -326,15 +286,11 @@ ClockSync::InternalEstimate ClockSync::computeInternalEstimate() const {
         // otherwise, but a sample-count term would be better still.
         e.uncertainty_ns = std::max<int64_t>(700'000,  // ONE_WAY_DELAY_ESTIMATE_NS
                                              m_data_spread_ns.value_or(0) / 2);
-        dbg("data-floor", e);
         return e;
     }
 
-    if (!m_probe_samples.empty()) {
-        auto e = bestProbe();
-        dbg("probe-unreliable", e);
-        return e;
-    }
+    if (!m_probe_samples.empty())
+        return bestProbe();
 
     return InternalEstimate{};  // offset_ns == nullopt
 }

--- a/src/cbsdk/include/cbsdk/cbsdk.h
+++ b/src/cbsdk/include/cbsdk/cbsdk.h
@@ -407,6 +407,20 @@ CBSDK_API uint32_t cbsdk_session_get_protocol_version(cbsdk_session_t session);
 /// @return Number of bytes written (excluding null terminator), or 0 if unavailable
 CBSDK_API uint32_t cbsdk_session_get_proc_ident(cbsdk_session_t session, char* buf, uint32_t buf_size);
 
+/// Get the channel range this instrument claims in the host's channel space
+///
+/// Central packs instruments densely and renumbers when the set of connected
+/// devices changes, so this is the authoritative mapping and cannot be derived
+/// from compile-time constants.
+///
+/// @param session Session handle
+/// @param out_chanbase Receives the lowest channel id claimed by this instrument
+/// @param out_chancount Receives the number of channel ids it claims
+/// @return CBSDK_RESULT_SUCCESS on success
+CBSDK_API cbsdk_result_t cbsdk_session_get_proc_chan_range(cbsdk_session_t session,
+                                                           uint32_t* out_chanbase,
+                                                           uint32_t* out_chancount);
+
 /// Get the global spike event length (samples per spike waveform)
 /// @param session Session handle (must not be NULL)
 /// @return Spike length in samples, or 0 if unavailable
@@ -435,8 +449,26 @@ CBSDK_API cbsdk_result_t cbsdk_session_set_spike_length(
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Get the number of channels
+///
+/// @deprecated This is the cbproto wire constant for a single instrument. It
+/// cannot describe the attached device, and under a multi-instrument Central it
+/// is far too small to index the aggregated channel space. Use
+/// cbsdk_session_get_max_chans() instead.
+///
 /// @return cbMAXCHANS (compile-time constant)
 CBSDK_API uint32_t cbsdk_get_max_chans(void);
+
+/// Get the number of channels the session's device actually has
+///
+/// Channel ids are local to the device in both STANDALONE and CLIENT modes, so
+/// valid ids are 1..N. A Gemini hub reports 256 (front-end only); a legacy
+/// analog NSP reports its full complement including physical I/O.
+///
+/// @param session Session handle
+/// @param out_max_chans Receives the channel count
+/// @return CBSDK_RESULT_SUCCESS on success
+CBSDK_API cbsdk_result_t cbsdk_session_get_max_chans(cbsdk_session_t session,
+                                                    uint32_t* out_max_chans);
 
 /// Get the number of front-end channels
 /// @return cbNUM_FE_CHANS (compile-time constant)

--- a/src/cbsdk/include/cbsdk/sdk_session.h
+++ b/src/cbsdk/include/cbsdk/sdk_session.h
@@ -462,6 +462,30 @@ public:
     /// @return Current run level (cbRUNLEVEL_*), or 0 if unknown
     uint32_t getRunLevel() const;
 
+    /// Get this instrument's processor information
+    ///
+    /// procinfo.chanbase and procinfo.chancount give the channel range this
+    /// instrument claims in the host's channel space. Central packs
+    /// instruments densely and renumbers them when the connected set changes,
+    /// so this is the authoritative mapping.
+    ///
+    /// @return Result containing the procinfo, or an error if unavailable
+    Result<cbPKT_PROCINFO> getProcInfo() const;
+
+    /// Get the number of channels this device actually has
+    ///
+    /// Channel ids in this API are always local to the device, so a session is
+    /// addressed 1..getMaxChans() whether it owns the device (STANDALONE) or
+    /// reads it through Central (CLIENT). A Gemini hub reports 256 — it is
+    /// front-end only, and the physical I/O lives on the NSP — while a legacy
+    /// analog NSP reports the full cbMAXCHANS complement.
+    ///
+    /// Prefer this over the free function cbsdk_get_max_chans(), which cannot
+    /// account for the attached device or Central version.
+    ///
+    /// @return Channel count for this device
+    uint32_t getMaxChans() const;
+
     /// Whether this session owns the device connection (STANDALONE mode).
     /// Returns false if attached to another process's shared memory (CLIENT mode).
     bool isStandalone() const;

--- a/src/cbsdk/src/cbsdk.cpp
+++ b/src/cbsdk/src/cbsdk.cpp
@@ -684,6 +684,21 @@ uint32_t cbsdk_session_get_proc_ident(cbsdk_session_t session, char* buf, uint32
     } catch (...) { buf[0] = '\0'; return 0; }
 }
 
+cbsdk_result_t cbsdk_session_get_proc_chan_range(cbsdk_session_t session,
+                                                 uint32_t* out_chanbase,
+                                                 uint32_t* out_chancount) {
+    if (!session || !session->cpp_session || !out_chanbase || !out_chancount) {
+        return CBSDK_RESULT_INVALID_PARAMETER;
+    }
+    try {
+        auto info = session->cpp_session->getProcInfo();
+        if (info.isError()) return CBSDK_RESULT_INTERNAL_ERROR;
+        *out_chanbase = info.value().chanbase;
+        *out_chancount = info.value().chancount;
+        return CBSDK_RESULT_SUCCESS;
+    } catch (...) { return CBSDK_RESULT_INTERNAL_ERROR; }
+}
+
 uint32_t cbsdk_session_get_spike_length(cbsdk_session_t session) {
     if (!session || !session->cpp_session) return 0;
     try {
@@ -719,6 +734,18 @@ cbsdk_result_t cbsdk_session_set_spike_length(
 
 uint32_t cbsdk_get_max_chans(void) {
     return cbMAXCHANS;
+}
+
+cbsdk_result_t cbsdk_session_get_max_chans(cbsdk_session_t session, uint32_t* out_max_chans) {
+    if (!session || !session->cpp_session || !out_max_chans) {
+        return CBSDK_RESULT_INVALID_PARAMETER;
+    }
+    try {
+        *out_max_chans = session->cpp_session->getMaxChans();
+        return CBSDK_RESULT_SUCCESS;
+    } catch (...) {
+        return CBSDK_RESULT_INTERNAL_ERROR;
+    }
 }
 
 uint32_t cbsdk_get_num_fe_chans(void) {

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -2469,9 +2469,43 @@ Result<void> SdkSession::saveCCF(const std::string& filename) {
         ccf::extractDeviceConfig(m_impl->device_session->getDeviceConfig(), ccf_data);
     } else if (m_impl->shmem_session) {
         const auto* native = m_impl->shmem_session->getNativeConfigBuffer();
-        if (!native)
-            return Result<void>::error("No configuration available in shared memory");
-        extractFromNativeConfig(*native, ccf_data);
+        if (native) {
+            extractFromNativeConfig(*native, ccf_data);
+        } else {
+            // CENTRAL: getNativeConfigBuffer() is NATIVE-only, so a CENTRAL
+            // CLIENT had no way to reach its configuration and every save
+            // failed. Translate Central's layout into the native form first.
+            // Heap-allocated: NativeConfigBuffer is far too large for the stack.
+            auto legacy = std::make_unique<cbshm::NativeConfigBuffer>();
+            auto r = m_impl->shmem_session->getLegacyConfigBuffer(*legacy);
+            if (r.isError())
+                return Result<void>::error("No configuration available in shared memory: " +
+                                           r.error());
+            extractFromNativeConfig(*legacy, ccf_data);
+
+            // The CCF describes the device this session speaks for, matching
+            // the rest of the API: this instrument's channels, in this
+            // instrument's numbering.
+            //
+            // extractFromNativeConfig copies the first cbMAXCHANS entries
+            // straight out of Central's globally-indexed space. On a
+            // multi-instrument Central that is the wrong set: with two hubs it
+            // yielded Hub1's 256 channels plus Hub2's first 28 sitting in the
+            // slots reserved for analog/Experiment I/O, and silently dropped
+            // everything past 284 of Central's 880. Loading such a file back
+            // would have written one device's settings onto another's.
+            //
+            // Everything else in the CCF (filters, sorting, LNC, waveforms,
+            // n-trodes, sysinfo) is system-wide and is kept as extracted.
+            std::memset(ccf_data.isChan, 0, sizeof(ccf_data.isChan));
+            const uint32_t n_local = std::min<uint32_t>(m_impl->local_max_chans, cbMAXCHANS);
+            for (uint32_t local = 1; local <= n_local; ++local) {
+                auto ci = m_impl->getChanInfo(local);
+                if (ci.isError()) continue;
+                ccf_data.isChan[local - 1] = ci.value();
+                ccf_data.isChan[local - 1].chan = local;
+            }
+        }
     } else {
         return Result<void>::error("No session available");
     }

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -2119,21 +2119,23 @@ Result<void> SdkSession::setChannelConfig(const cbPKT_CHANINFO& chaninfo) {
     if (m_impl->device_session)
         return m_impl->device_session->setChannelConfig(chaninfo);
 
-    // CLIENT: the caller addressed a local (per-device) channel, but Central
-    // routes on its global id, so translate before handing the packet over.
-    // Without this a HUB2 setter would land on HUB1's channel of the same
-    // number.
-    const uint32_t global = m_impl->toGlobalChan(chaninfo.chan);
-    if (!global) {
+    // CLIENT: validate against this device's window, but send the channel id
+    // unchanged.
+    //
+    // Only Central's shared-memory chaninfo[] is indexed globally. Central
+    // forwards transmit-buffer packets to the instrument network verbatim
+    // (InstNetwork drains the buffer straight into Instrument::Send, which is a
+    // plain UDP send with no per-instrument routing), so the device receives
+    // exactly what we wrote and applies it using its own numbering -- Hub2's
+    // channels are 1..256 to Hub2, whatever Central calls them. Routing is by
+    // cbpkt_header.instrument, which sendPacket() stamps.
+    //
+    // Translating the id here would send Hub2 a channel 257 it does not have.
+    if (!m_impl->toGlobalChan(chaninfo.chan)) {
         return Result<void>::error("Channel " + std::to_string(chaninfo.chan) +
                                    " is not present on this device");
     }
-    if (global == chaninfo.chan) {
-        return sendPacket(reinterpret_cast<const cbPKT_GENERIC&>(chaninfo));
-    }
-    cbPKT_CHANINFO translated = chaninfo;
-    translated.chan = global;
-    return sendPacket(reinterpret_cast<const cbPKT_GENERIC&>(translated));
+    return sendPacket(reinterpret_cast<const cbPKT_GENERIC&>(chaninfo));
 }
 
 ///--------------------------------------------------------------------------------------------
@@ -2726,6 +2728,21 @@ Result<void> SdkSession::sendPacket(const cbPKT_GENERIC& pkt) {
     cbPKT_GENERIC stamped = pkt;
     PROCTIME t = m_impl->shmem_session->getLastTime();
     stamped.cbpkt_header.time = (t != 0) ? t : 1;
+
+    // Address the packet to this session's instrument so the fabric routes it
+    // to the right device and any reply carries the matching instrument index.
+    // Without this every outbound packet is addressed to instrument 0: a
+    // non-zero-index session's reply is then dropped by readReceiveBuffer's
+    // instrument filter and every wait times out. That is why sync() -- a
+    // runlevel SET plus a wait for SYSREPRUNLEV -- succeeded only for
+    // instrument 0, taking every auto_sync setter down with it on the others.
+    //
+    // Stamping here covers every CLIENT-mode send at once: runlevel,
+    // REQCONFIGALL, channel config, comments, digital output and file control.
+    // The clock probe already sets the same value explicitly, so it is
+    // unchanged; NATIVE is instrument 0 either way.
+    stamped.cbpkt_header.instrument =
+        m_impl->shmem_session->getInstrument().toPacketField();
 
     auto result = m_impl->shmem_session->enqueuePacket(stamped);
     if (result.isOk()) {

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -296,6 +296,139 @@ struct SdkSession::Impl {
     ErrorCallback error_callback;
     std::mutex user_callback_mutex;
 
+    ///////////////////////////////////////////////////////////////////////////
+    // Per-instrument channel window
+    //
+    // Central numbers channels globally across every instrument (Hub1 1-256,
+    // Hub2 257-512, ...), but the public API presents each device as an
+    // independent 1-based device so that CENTRAL CLIENT and STANDALONE look
+    // identical to a caller: HUB2's channel 1 is 1, not 257.  These segments
+    // map this session's local ids onto Central's global ids.
+    //
+    // Local numbering follows the cbproto *wire* layout (FE 1..256, then ANAIN,
+    // ANAOUT, AUDOUT, DIGIN, SERIAL, DIGOUT), which is exactly one instrument's
+    // complement.  On a single-instrument system the map is the identity, so
+    // nothing changes for legacy setups.
+    struct ChanSeg {
+        uint32_t local_start;   ///< 1-based, inclusive
+        uint32_t count;
+        uint32_t global_start;  ///< 1-based, inclusive
+    };
+    // Mutable so an unresolved window can still be resolved from const
+    // accessors -- see ensureWindowResolved().
+    mutable std::vector<ChanSeg> chan_segs;         ///< the mapped ranges
+    mutable bool window_resolved = false;           ///< false => identity map (unknown)
+    mutable uint32_t local_max_chans = cbMAXCHANS;  ///< channels this device has
+    uint32_t central_instrument = 0;                ///< instrument this session speaks for
+
+    /// @brief Resolve the window on first use if it could not be resolved yet
+    ///
+    /// procinfo can lag session setup by an unpredictable amount -- a Gemini
+    /// NSP resolved on three opens out of four with a one-second wait -- and an
+    /// unresolved window silently reports the whole wire space. Retrying at the
+    /// point of use removes the timing sensitivity entirely; once resolved this
+    /// is a single bool test.
+    void ensureWindowResolved() const {
+        if (!window_resolved) {
+            const_cast<Impl*>(this)->buildChannelWindow(central_instrument);
+        }
+    }
+
+    /// @brief Map a local (per-device) channel id onto Central's global id
+    /// @return the global id, or 0 if this device has no such channel
+    uint32_t toGlobalChan(const uint32_t local) const {
+        if (local < 1 || local > local_max_chans) return 0;
+        // An unresolved window is the identity; a resolved but empty one means
+        // the device is not present and nothing is addressable.
+        if (!window_resolved) return local;
+        for (const auto& s : chan_segs) {
+            if (local >= s.local_start && local < s.local_start + s.count)
+                return s.global_start + (local - s.local_start);
+        }
+        return 0;
+    }
+
+    /// @brief Inverse of toGlobalChan()
+    ///
+    /// Returns 0 when the global id belongs to a different instrument, which is
+    /// how packets for other devices are recognised and ignored.
+    uint32_t toLocalChan(const uint32_t global) const {
+        if (global < 1) return 0;
+        if (!window_resolved) return global <= local_max_chans ? global : 0;
+        for (const auto& s : chan_segs) {
+            if (global >= s.global_start && global < s.global_start + s.count)
+                return s.local_start + (global - s.global_start);
+        }
+        return 0;
+    }
+
+    /// @brief Build the local->global window for this instrument
+    ///
+    /// The mapping cannot be computed from compile-time constants.  Central
+    /// packs the connected instruments densely into one channel space and
+    /// renumbers them whenever that set changes: with two hubs the NSP's
+    /// analog inputs start at 513, with one hub at 257, with none at 1.  So the
+    /// window is discovered at runtime from procinfo, which Central maintains.
+    ///
+    /// Each instrument's channels are contiguous, so the window is a single
+    /// range: local 1..chancount maps to global base..base+chancount-1, where
+    /// base is 1 plus the running sum of the preceding instruments' chancount.
+    /// A device reporting chancount 0 is not present.
+    void buildChannelWindow(const uint32_t instrument) {
+        chan_segs.clear();
+        window_resolved = false;
+        local_max_chans = cbMAXCHANS;
+        if (!shmem_session) return;
+
+        const uint32_t max_procs = std::max<uint32_t>(shmem_session->getMaxProcs(), 1);
+        if (instrument >= max_procs) return;
+
+        uint32_t base = 1;
+        uint32_t count = 0;
+        uint32_t total = 0;
+        for (uint32_t i = 0; i < max_procs; ++i) {
+            auto pi = shmem_session->getProcInfoAt(i);
+            const uint32_t cc = pi.isOk() ? pi.value().chancount : 0;
+            total += cc;
+            if (i < instrument) base += cc;
+            else if (i == instrument) count = cc;
+        }
+
+        // Every instrument reporting zero means procinfo has not been populated
+        // yet rather than that nothing is connected.  Leave the window
+        // unresolved so the session degrades to the wire space instead of
+        // having no addressable channels at all.
+        if (total == 0) return;
+
+        // Resolved.  A zero count here means this instrument really is absent,
+        // so the window stays empty and every channel id is rejected — a
+        // session for a disconnected device must not read another one's data.
+        window_resolved = true;
+        if (count == 0) {
+            local_max_chans = 0;
+            return;
+        }
+        chan_segs.push_back({1, count, base});
+        local_max_chans = count;
+    }
+
+    /// @brief Resolve the channel window, retrying briefly if procinfo lags
+    ///
+    /// procinfo.chancount only becomes meaningful once the device has answered
+    /// REQCONFIGALL (STANDALONE) or the owner has published it (CLIENT), and
+    /// both can lag the point where a session is otherwise ready. Observed on a
+    /// Gemini NSP, which resolved on some session opens and not others.
+    /// An unresolved window silently reports the whole wire space, so it is
+    /// worth a bounded wait here rather than a wrong answer for the session's
+    /// lifetime.
+    void resolveChannelWindow(const int attempts = 20) {
+        for (int i = 0; i < attempts; ++i) {
+            buildChannelWindow(central_instrument);
+            if (window_resolved) return;
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+    }
+
     // Channel type cache — pre-computed at config time, avoids per-packet getChanInfo() (Phase 3, Fix 10)
     std::array<ChannelType, cbMAXCHANS> channel_type_cache;
     bool channel_cache_valid = false;
@@ -306,20 +439,34 @@ struct SdkSession::Impl {
     std::mutex cmp_mutex;
 
     void rebuildChannelTypeCache() {
-        for (uint32_t ch = 0; ch < cbMAXCHANS; ++ch) {
+        channel_type_cache.fill(ChannelType::ANY);
+        for (uint32_t ch = 0; ch < local_max_chans; ++ch) {
             auto ci = getChanInfo(ch + 1);
             channel_type_cache[ch] = ci.isOk() ? classifyChannelByCaps(ci.value()) : ChannelType::ANY;
         }
         channel_cache_valid = true;
     }
 
-    // Helper: get chaninfo for a 1-based channel ID
+    // Helper: get chaninfo for a 1-based *local* channel ID
     Result<cbPKT_CHANINFO> getChanInfo(const uint32_t chan_id) const {
+        // Reject ids this device does not have before choosing a backing
+        // store, so the answer cannot depend on which one replies.  A hub has
+        // no I/O channels, but the wire layout still reserves slots at 257..,
+        // and the device happily returns the empty chaninfo sitting there.
+        ensureWindowResolved();
+        const uint32_t global = toGlobalChan(chan_id);
+        if (!global) {
+            return Result<cbPKT_CHANINFO>::error("Channel not present on this device");
+        }
         // Prefer shmem over device_config because CMP position overlays are
         // written to shmem (device_config is owned by the receive thread and
         // we avoid writing to it from other threads).
-        if (shmem_session && chan_id >= 1 && chan_id <= cbMAXCHANS) {
-            return shmem_session->getChanInfo(chan_id - 1);
+        //
+        // chaninfo[] is indexed in Central's global space, so the translated id
+        // is the right index there; device_session talks to the device
+        // directly, which numbers channels locally.
+        if (shmem_session) {
+            return shmem_session->getChanInfo(global - 1);
         }
         // Fallback to device_config (no shmem available)
         if (device_session) {
@@ -466,7 +613,7 @@ struct SdkSession::Impl {
         std::lock_guard<std::mutex> lock(cmp_mutex);
         if (cmp_entries.empty()) return;
 
-        for (uint32_t chan_id = 1; chan_id <= cbMAXCHANS; ++chan_id) {
+        for (uint32_t chan_id = 1; chan_id <= local_max_chans; ++chan_id) {
             // Snapshot chaninfo to avoid racing with the receive thread
             cbPKT_CHANINFO ci{};
             bool valid = false;
@@ -499,6 +646,28 @@ struct SdkSession::Impl {
     /// Dispatch a batch of packets: first fire batch group callbacks, then per-packet callbacks.
     /// Called from both STANDALONE callback thread and CLIENT shmem receive thread.
     void dispatchBatch(cbPKT_GENERIC* packets, size_t count) {
+        // Central stamps packet chids in its global space (Hub2's channel 1
+        // arrives as 257), so rewrite them into this device's local space
+        // before any dispatch.  Doing it here covers the batch and per-packet
+        // paths at once and keeps callbacks identical to STANDALONE.
+        //
+        // An identity map — NATIVE, STANDALONE, or a single-instrument
+        // Central — skips the loop entirely, so the hot path is unaffected.
+        if (!chan_segs.empty()) {
+            for (size_t i = 0; i < count; i++) {
+                const uint16_t chid = packets[i].cbpkt_header.chid;
+                // chid 0 is a sample group and the high bit marks configuration
+                // packets; neither is a channel id.
+                if (chid == 0 || (chid & cbPKTCHAN_CONFIGURATION)) continue;
+                const uint32_t local = toLocalChan(chid);
+                // 0 means the channel belongs to another instrument, which the
+                // receive-buffer instrument filter should already have dropped.
+                // Leave it alone rather than rewriting it to 0, which would
+                // masquerade as a sample group.
+                if (local) packets[i].cbpkt_header.chid = static_cast<uint16_t>(local);
+            }
+        }
+
         // Phase 1: batch group callbacks (one invocation per group_id per batch)
         std::vector<GroupBatchCB> snap_batch;
         {
@@ -574,7 +743,7 @@ struct SdkSession::Impl {
         if (chid != 0 && !(chid & cbPKTCHAN_CONFIGURATION)) {
             // Look up cached channel type (Phase 3, Fix 10)
             ChannelType pkt_chan_type = ChannelType::ANY;
-            if (channel_cache_valid && chid >= 1 && chid <= cbMAXCHANS) {
+            if (channel_cache_valid && chid >= 1 && chid <= local_max_chans) {
                 pkt_chan_type = channel_type_cache[chid - 1];
             }
             for (const auto& cb : snap_event) {
@@ -748,6 +917,26 @@ Result<SdkSession> SdkSession::create(const SdkConfig& config) {
     session.m_impl->shmem_session = std::move(shmem_result.value());
     session.m_impl->standalone = is_standalone;
 
+    // Establish this session's local->global channel window.  NATIVE and
+    // STANDALONE own a single instrument, so index 0 is theirs.
+    //
+    // For CENTRAL the config is already sitting in shared memory, so this
+    // resolves immediately.  A STANDALONE session has not downloaded the
+    // device's config yet and will resolve to the identity map here; it is
+    // rebuilt after the handshake, once procinfo is populated.
+    {
+        // Only the CENTRAL layout aggregates instruments, so only there does
+        // the device type select a non-zero index.  NATIVE shared memory holds
+        // a single instrument whichever device produced it -- including for a
+        // NATIVE CLIENT, which is not standalone but is still single-instrument.
+        const int32_t inst_idx = getCentralInstrumentIndex(config.device_type);
+        const bool central_layout =
+            session.m_impl->shmem_session->getLayout() == cbshm::ShmemLayout::CENTRAL;
+        session.m_impl->central_instrument =
+            central_layout && inst_idx >= 0 ? static_cast<uint32_t>(inst_idx) : 0u;
+        session.m_impl->buildChannelWindow(session.m_impl->central_instrument);
+    }
+
     // Create device session only in STANDALONE mode
     if (is_standalone) {
         // Map SDK DeviceType to cbdev DeviceType
@@ -817,6 +1006,8 @@ Result<SdkSession> SdkSession::create(const SdkConfig& config) {
         if (start_result.isError()) {
             return Result<SdkSession>::error("Failed to start CLIENT session: " + start_result.error());
         }
+        // Resolve the channel window before the type cache, which it sizes.
+        session.m_impl->resolveChannelWindow();
         // Build channel type cache from existing shmem config
         session.m_impl->rebuildChannelTypeCache();
     }
@@ -1543,6 +1734,11 @@ Result<cbPKT_FILTINFO> SdkSession::getFilterInfo(const uint32_t filter_id) const
     return Result<cbPKT_FILTINFO>::error("Filter information not available");
 }
 
+uint32_t SdkSession::getMaxChans() const {
+    m_impl->ensureWindowResolved();
+    return m_impl->local_max_chans;
+}
+
 uint32_t SdkSession::getRunLevel() const {
     uint32_t rl = m_impl->device_runlevel.load(std::memory_order_acquire);
     if (rl != 0) return rl;
@@ -1591,6 +1787,20 @@ std::string SdkSession::getProcIdent() const {
         }
     }
     return {};
+}
+
+Result<cbPKT_PROCINFO> SdkSession::getProcInfo() const {
+    if (m_impl->device_session) {
+        return Result<cbPKT_PROCINFO>::ok(m_impl->device_session->getDeviceConfig().procinfo);
+    }
+    if (m_impl->shmem_session) {
+        const auto* native = m_impl->shmem_session->getNativeConfigBuffer();
+        if (native) {
+            return Result<cbPKT_PROCINFO>::ok(native->procinfo);
+        }
+        return m_impl->shmem_session->getProcInfo();
+    }
+    return Result<cbPKT_PROCINFO>::error("Processor information not available");
 }
 
 uint32_t SdkSession::getSpikeLength() const {
@@ -1905,9 +2115,25 @@ Result<void> SdkSession::setACInputCoupling(
 }
 
 Result<void> SdkSession::setChannelConfig(const cbPKT_CHANINFO& chaninfo) {
+    // STANDALONE talks to the device directly, where ids are already local.
     if (m_impl->device_session)
         return m_impl->device_session->setChannelConfig(chaninfo);
-    return sendPacket(reinterpret_cast<const cbPKT_GENERIC&>(chaninfo));
+
+    // CLIENT: the caller addressed a local (per-device) channel, but Central
+    // routes on its global id, so translate before handing the packet over.
+    // Without this a HUB2 setter would land on HUB1's channel of the same
+    // number.
+    const uint32_t global = m_impl->toGlobalChan(chaninfo.chan);
+    if (!global) {
+        return Result<void>::error("Channel " + std::to_string(chaninfo.chan) +
+                                   " is not present on this device");
+    }
+    if (global == chaninfo.chan) {
+        return sendPacket(reinterpret_cast<const cbPKT_GENERIC&>(chaninfo));
+    }
+    cbPKT_CHANINFO translated = chaninfo;
+    translated.chan = global;
+    return sendPacket(reinterpret_cast<const cbPKT_GENERIC&>(translated));
 }
 
 ///--------------------------------------------------------------------------------------------
@@ -2153,7 +2379,7 @@ Result<void> SdkSession::loadChannelMap(
         std::vector<std::pair<uint32_t, std::string>> labels_to_push;
         {
             std::lock_guard<std::mutex> lock(m_impl->cmp_mutex);
-            for (uint32_t chan_id = 1; chan_id <= cbMAXCHANS; ++chan_id) {
+            for (uint32_t chan_id = 1; chan_id <= m_impl->local_max_chans; ++chan_id) {
                 auto info = getChanInfo(chan_id);
                 if (info.isError() || info.value().chan == 0) continue;
                 auto it = m_impl->cmp_entries.find(cmpKey(info.value().bank, info.value().term));
@@ -2184,7 +2410,7 @@ Result<void> SdkSession::clearChannelMap() {
     {
         std::lock_guard<std::mutex> lock(m_impl->cmp_mutex);
         if (!m_impl->cmp_entries.empty()) {
-            for (uint32_t chan_id = 1; chan_id <= cbMAXCHANS; ++chan_id) {
+            for (uint32_t chan_id = 1; chan_id <= m_impl->local_max_chans; ++chan_id) {
                 auto info = getChanInfo(chan_id);
                 if (info.isError() || info.value().chan == 0) continue;
                 if (m_impl->cmp_entries.count(cmpKey(info.value().bank, info.value().term))) {
@@ -2749,7 +2975,11 @@ request_config:
     }
 
     // Success - device is now in RUNNING state
-    // Build channel type cache now that config is populated
+    // Resolve the channel window and build the type cache now that config is
+    // populated. procinfo.chancount is only meaningful once the device has
+    // answered REQCONFIGALL, so the window built during create() was still the
+    // identity fallback.
+    m_impl->resolveChannelWindow();
     m_impl->rebuildChannelTypeCache();
     return Result<void>::ok();
 }

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <iostream>
 #include <algorithm>
+#include <map>
 #include <set>
 #include <vector>
 #include <unordered_map>
@@ -501,6 +502,94 @@ struct SdkSession::Impl {
     };
     PendingClockProbe pending_clock_probe;
     std::mutex clock_probe_mutex;
+
+    // CENTRAL-mode cross-instrument clock estimates.
+    //
+    // A STANDALONE owner borrows a peer's offset through the peer's own shared
+    // memory (see peer_hubs above) -- notably a Gemini NSP borrowing a hub,
+    // because the NSP transmits in ~8192-sample bursts and its probe replies
+    // are latched to those boundaries, quantising every offset by up to 273 ms.
+    // Under CENTRAL there is no peer CereLink process publishing anything, so
+    // that mechanism finds nothing and the NSP is stuck with its own unusable
+    // probes.
+    //
+    // Central's ring already carries every instrument's packets though, so the
+    // estimates can be built here instead: the packet observer sees the other
+    // instruments' probe replies before the demux filter discards them, and the
+    // same vote/borrow rules are applied to the result. The library resolves
+    // this itself -- callers should never have to assemble a clock estimate.
+    struct PeerInstrumentClock {
+        cbdev::ClockSync sync;
+        PendingClockProbe pending;
+    };
+    std::map<uint32_t, PeerInstrumentClock> peer_instrument_clocks;
+    std::mutex peer_instrument_mutex;
+
+    /// @brief Feed a probe reply belonging to another instrument
+    ///
+    /// Called from the packet observer, i.e. on the reading thread, for replies
+    /// the demux filter is about to discard.
+    void addPeerProbeReply(uint32_t instrument, uint64_t device_time_ns,
+                           std::chrono::steady_clock::time_point t4) {
+        std::lock_guard<std::mutex> lk(peer_instrument_mutex);
+        auto it = peer_instrument_clocks.find(instrument);
+        if (it == peer_instrument_clocks.end() || !it->second.pending.active) return;
+        it->second.sync.addProbeSample(it->second.pending.t1_local, device_time_ns, t4);
+        it->second.pending.active = false;
+    }
+
+    /// @brief Vote across instruments and commit the result to this session
+    ///
+    /// Mirrors the STANDALONE rules deliberately, so the two modes agree:
+    /// three or more independent estimates elect a median; below that an
+    /// instrument with no usable estimate of its own borrows the
+    /// lowest-uncertainty peer. ClockSync::setExternalOffset sanity-checks the
+    /// value before adopting it, which is what keeps this safe on hardware
+    /// whose instruments are not commonly disciplined -- a peer that disagrees
+    /// is rejected rather than believed.
+    void applyCrossInstrumentConsensus() {
+        std::vector<int64_t> votes;
+        std::optional<int64_t> best_peer_offset;
+        std::optional<int64_t> best_peer_uncert;
+        int64_t best_uncert_val = INT64_MAX;
+        {
+            std::lock_guard<std::mutex> lk(peer_instrument_mutex);
+            for (auto& [inst, pc] : peer_instrument_clocks) {
+                auto off = pc.sync.getOffsetNs();
+                if (!off) continue;
+                votes.push_back(*off);
+                const int64_t unc = pc.sync.getUncertaintyNs().value_or(INT64_MAX);
+                if (!best_peer_offset || unc < best_uncert_val) {
+                    best_peer_offset = off;
+                    best_peer_uncert = pc.sync.getUncertaintyNs();
+                    best_uncert_val = unc;
+                }
+            }
+        }
+        const auto own = client_clock_sync.getOffsetNs();
+        if (own) votes.push_back(*own);
+
+        if (votes.size() >= 3) {
+            std::sort(votes.begin(), votes.end());
+            client_clock_sync.setExternalOffset(votes[votes.size() / 2]);
+        } else if (best_peer_offset) {
+            client_clock_sync.setExternalOffset(best_peer_offset, best_peer_uncert);
+        } else {
+            client_clock_sync.setExternalOffset(std::nullopt);
+        }
+    }
+
+    /// Instruments present in Central, discovered from procinfo.chancount.
+    std::vector<uint32_t> presentInstruments() const {
+        std::vector<uint32_t> out;
+        if (!shmem_session) return out;
+        const uint32_t max_procs = std::max<uint32_t>(shmem_session->getMaxProcs(), 1);
+        for (uint32_t i = 0; i < max_procs; ++i) {
+            auto pi = shmem_session->getProcInfoAt(i);
+            if (pi.isOk() && pi.value().chancount > 0) out.push_back(i);
+        }
+        return out;
+    }
 
     // Per-stream monotonic-conversion state (see toLocalTimeBatch).  Each stream
     // keeps its own non-decreasing floor and the discontinuity epoch it last
@@ -1384,6 +1473,26 @@ Result<void> SdkSession::start() {
 
         m_impl->shmem_receive_thread_running.store(true);
         Impl* impl = m_impl.get();
+
+        // Catch the other instruments' probe replies before the demux filter
+        // discards them, so this session can build a cross-device estimate
+        // without a peer CereLink process to borrow one from. Only replies are
+        // taken; the filter still decides what the session actually receives,
+        // so no foreign data reaches callbacks.
+        if (m_impl->shmem_session->getLayout() == cbshm::ShmemLayout::CENTRAL) {
+            const uint32_t self_inst = m_impl->shmem_session->getInstrument().toIndex();
+            m_impl->shmem_session->setPacketObserver(
+                [impl, self_inst](const cbPKT_GENERIC& pkt) {
+                    if (pkt.cbpkt_header.type != cbPKTTYPE_NPLAYREP) return;
+                    const uint32_t inst = pkt.cbpkt_header.instrument;
+                    if (inst == self_inst) return;  // own reply: handled below
+                    constexpr uint64_t STALENESS_CORRECTION_NS = 165000;
+                    impl->addPeerProbeReply(inst,
+                                            pkt.cbpkt_header.time + STALENESS_CORRECTION_NS,
+                                            std::chrono::steady_clock::now());
+                });
+        }
+
         m_impl->shmem_receive_thread = std::make_unique<std::thread>([impl]() {
             // CLIENT mode receive thread: reads from Central's cbRECbuffer, dispatches to callbacks
             constexpr size_t MAX_BATCH = 128;
@@ -1506,6 +1615,31 @@ Result<void> SdkSession::start() {
                             impl->shmem_session->enqueuePacket(
                                 *reinterpret_cast<const cbPKT_GENERIC*>(&probe));
                             impl->last_clock_probe_time = t4;
+
+                            // CENTRAL: also probe the other instruments, so this
+                            // session can build its own cross-device estimate.
+                            // Their replies come back on the same ring and are
+                            // caught by the packet observer before the demux
+                            // filter drops them.
+                            if (impl->shmem_session->getLayout() == cbshm::ShmemLayout::CENTRAL) {
+                                const uint32_t self = impl->shmem_session->getInstrument().toIndex();
+                                for (uint32_t inst : impl->presentInstruments()) {
+                                    if (inst == self) continue;
+                                    {
+                                        std::lock_guard<std::mutex> lk(impl->peer_instrument_mutex);
+                                        auto& pc = impl->peer_instrument_clocks[inst];
+                                        pc.pending.t1_local = t4;
+                                        pc.pending.active = true;
+                                    }
+                                    cbPKT_NPLAY peer_probe = probe;
+                                    peer_probe.cbpkt_header.instrument =
+                                        cbproto::InstrumentId::fromIndex(
+                                            static_cast<int32_t>(inst)).toPacketField();
+                                    impl->shmem_session->enqueuePacket(
+                                        *reinterpret_cast<const cbPKT_GENERIC*>(&peer_probe));
+                                }
+                                impl->applyCrossInstrumentConsensus();
+                            }
                         }
 
                         // Dispatch batch (fires batch group callbacks, then per-packet callbacks)

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -1541,6 +1541,7 @@ Result<void> SdkSession::start() {
 
                     if (packets_read > 0) {
                         auto t4 = std::chrono::steady_clock::now();
+                        uint64_t last_data_time = 0;
                         impl->stats.packets_delivered_to_callback.fetch_add(packets_read, std::memory_order_relaxed);
                         impl->stats.packets_received_from_device.fetch_add(packets_read, std::memory_order_relaxed);
                         uint64_t batch_bytes = 0;
@@ -1548,6 +1549,12 @@ Result<void> SdkSession::start() {
                         for (size_t i = 0; i < packets_read; i++) {
                             batch_bytes += static_cast<uint64_t>(
                                 cbPKT_HEADER_32SIZE + packets[i].cbpkt_header.dlen) * 4;
+                            // Remember the newest data-packet timestamp for the
+                            // fallback estimator (fed once per batch below).
+                            if (!(packets[i].cbpkt_header.chid & cbPKTCHAN_CONFIGURATION) &&
+                                packets[i].cbpkt_header.time != 0) {
+                                last_data_time = packets[i].cbpkt_header.time;
+                            }
                             if (packets[i].cbpkt_header.type == cbPKTTYPE_NPLAYREP) {
                                 // Complete pending clock sync probe
                                 constexpr uint64_t STALENESS_CORRECTION_NS = 165000;
@@ -1581,6 +1588,23 @@ Result<void> SdkSession::start() {
                         }
                         impl->stats.bytes_received_from_device.fetch_add(
                             batch_bytes, std::memory_order_relaxed);
+
+                        // Feed the fallback estimator once per batch, mirroring
+                        // DeviceSession. This is the only recourse for a device
+                        // whose probe replies are latched to transmit blocks
+                        // (a Gemini NSP quantises every offset by up to 273 ms)
+                        // when there is no peer instrument to borrow from --
+                        // an NSP alone under Central. No tick->ns conversion is
+                        // needed here: readReceiveBuffer already normalises
+                        // CLIENT timestamps for every device type.
+                        //
+                        // Selection order makes this self-limiting: reliable
+                        // probes still win, so a device with good probes is
+                        // unaffected and only one with unusable probes gains
+                        // the floor.
+                        if (last_data_time != 0) {
+                            impl->client_clock_sync.addDataPacketSample(last_data_time, t4);
+                        }
 
                         // Periodic clock sync probing (~every 5 seconds)
                         if (t4 - impl->last_clock_probe_time > std::chrono::seconds(2)) {

--- a/src/cbshm/include/cbshm/central_adapters/base.h
+++ b/src/cbshm/include/cbshm/central_adapters/base.h
@@ -160,6 +160,14 @@ public:
 
     /// Config read operations
     virtual cbutil::Result<void> getProcInfo(::cbPKT_PROCINFO& buf) const = 0;
+
+    /// @brief Read any instrument's procinfo, not just this adapter's own
+    ///
+    /// Central packs instruments densely into one channel space and renumbers
+    /// them when the connected set changes, so an instrument's base channel is
+    /// the running sum of the preceding instruments' chancount. Computing that
+    /// requires reading every procinfo, not only this one.
+    virtual cbutil::Result<void> getProcInfoAt(::cbPKT_PROCINFO& buf, uint32_t instrument) const = 0;
     virtual cbutil::Result<void> getBankInfo(::cbPKT_BANKINFO& buf, uint32_t bank_num) const = 0;
     virtual cbutil::Result<void> getFilterInfo(::cbPKT_FILTINFO& buf, uint32_t filter_num) const = 0;
     virtual cbutil::Result<void> getChanInfo(::cbPKT_CHANINFO& buf, uint32_t channel_idx) const = 0;

--- a/src/cbshm/include/cbshm/central_adapters/v7_0.h
+++ b/src/cbshm/include/cbshm/central_adapters/v7_0.h
@@ -161,6 +161,7 @@ public:
 
     /// Config read operations
     cbutil::Result<void> getProcInfo(::cbPKT_PROCINFO& buf) const override;
+    cbutil::Result<void> getProcInfoAt(::cbPKT_PROCINFO& buf, uint32_t instrument) const override;
     cbutil::Result<void> getBankInfo(::cbPKT_BANKINFO& buf, uint32_t bank_num) const override;
     cbutil::Result<void> getFilterInfo(::cbPKT_FILTINFO& buf, uint32_t filter_num) const override;
     cbutil::Result<void> getChanInfo(::cbPKT_CHANINFO& buf, uint32_t channel_idx) const override;

--- a/src/cbshm/include/cbshm/central_adapters/v7_5.h
+++ b/src/cbshm/include/cbshm/central_adapters/v7_5.h
@@ -161,6 +161,7 @@ public:
 
     /// Config read operations
     cbutil::Result<void> getProcInfo(::cbPKT_PROCINFO& buf) const override;
+    cbutil::Result<void> getProcInfoAt(::cbPKT_PROCINFO& buf, uint32_t instrument) const override;
     cbutil::Result<void> getBankInfo(::cbPKT_BANKINFO& buf, uint32_t bank_num) const override;
     cbutil::Result<void> getFilterInfo(::cbPKT_FILTINFO& buf, uint32_t filter_num) const override;
     cbutil::Result<void> getChanInfo(::cbPKT_CHANINFO& buf, uint32_t channel_idx) const override;

--- a/src/cbshm/include/cbshm/central_adapters/v7_6.h
+++ b/src/cbshm/include/cbshm/central_adapters/v7_6.h
@@ -161,6 +161,7 @@ public:
 
     /// Config read operations
     cbutil::Result<void> getProcInfo(::cbPKT_PROCINFO& buf) const override;
+    cbutil::Result<void> getProcInfoAt(::cbPKT_PROCINFO& buf, uint32_t instrument) const override;
     cbutil::Result<void> getBankInfo(::cbPKT_BANKINFO& buf, uint32_t bank_num) const override;
     cbutil::Result<void> getFilterInfo(::cbPKT_FILTINFO& buf, uint32_t filter_num) const override;
     cbutil::Result<void> getChanInfo(::cbPKT_CHANINFO& buf, uint32_t channel_idx) const override;

--- a/src/cbshm/include/cbshm/central_adapters/v7_7.h
+++ b/src/cbshm/include/cbshm/central_adapters/v7_7.h
@@ -161,6 +161,7 @@ public:
 
     /// Config read operations
     cbutil::Result<void> getProcInfo(::cbPKT_PROCINFO& buf) const override;
+    cbutil::Result<void> getProcInfoAt(::cbPKT_PROCINFO& buf, uint32_t instrument) const override;
     cbutil::Result<void> getBankInfo(::cbPKT_BANKINFO& buf, uint32_t bank_num) const override;
     cbutil::Result<void> getFilterInfo(::cbPKT_FILTINFO& buf, uint32_t filter_num) const override;
     cbutil::Result<void> getChanInfo(::cbPKT_CHANINFO& buf, uint32_t channel_idx) const override;

--- a/src/cbshm/include/cbshm/central_adapters/v7_8.h
+++ b/src/cbshm/include/cbshm/central_adapters/v7_8.h
@@ -161,6 +161,7 @@ public:
 
     /// Config read operations
     cbutil::Result<void> getProcInfo(::cbPKT_PROCINFO& buf) const override;
+    cbutil::Result<void> getProcInfoAt(::cbPKT_PROCINFO& buf, uint32_t instrument) const override;
     cbutil::Result<void> getBankInfo(::cbPKT_BANKINFO& buf, uint32_t bank_num) const override;
     cbutil::Result<void> getFilterInfo(::cbPKT_FILTINFO& buf, uint32_t filter_num) const override;
     cbutil::Result<void> getChanInfo(::cbPKT_CHANINFO& buf, uint32_t channel_idx) const override;

--- a/src/cbshm/include/cbshm/shmem_session.h
+++ b/src/cbshm/include/cbshm/shmem_session.h
@@ -19,6 +19,7 @@
 
 // Include Central-compatible types which bring in protocol definitions
 #include <cbshm/central_current.h>
+#include <cbshm/central_adapters/base.h>
 #include <cbshm/native_types.h>
 #include <cbproto/connection.h>
 #include <cbutil/result.h>
@@ -120,6 +121,17 @@ public:
     ///
     /// @return the maximum instrument count
     uint32_t getMaxProcs() const;
+
+    /// @brief Get any instrument's processor information
+    ///
+    /// Unlike getProcInfo(), which returns this session's own instrument, this
+    /// reads an arbitrary index. Central packs instruments densely into one
+    /// channel space, so an instrument's base channel is the running sum of the
+    /// preceding instruments' chancount — which requires reading all of them.
+    ///
+    /// @param instrument 0-based instrument index
+    /// @return cbPKT_PROCINFO structure on success
+    Result<cbPKT_PROCINFO> getProcInfoAt(uint32_t instrument) const;
 
     /// @}
 

--- a/src/cbshm/include/cbshm/shmem_session.h
+++ b/src/cbshm/include/cbshm/shmem_session.h
@@ -23,6 +23,7 @@
 #include <cbshm/native_types.h>
 #include <cbproto/connection.h>
 #include <cbutil/result.h>
+#include <functional>
 #include <memory>
 #include <string>
 #include <cstdint>
@@ -443,6 +444,25 @@ public:
     /// @param packets_read Output: actual number of packets read
     /// @return Result indicating success or failure
     Result<void> readReceiveBuffer(cbPKT_GENERIC* packets, size_t max_packets, size_t& packets_read);
+
+    /// @brief Observe every packet walked, before the instrument filter
+    ///
+    /// readReceiveBuffer() returns only this session's instrument's packets.
+    /// For the CENTRAL layout that discards the other instruments' packets,
+    /// which are nonetheless in the same ring and already inspected in order to
+    /// make the filter decision. An observer sees each one as it is walked.
+    ///
+    /// This exists because a CENTRAL CLIENT has no peer CereLink process to
+    /// borrow clock estimates from, so it must derive cross-device estimates
+    /// from the ring itself. Deliberately generic: the shm layer stays ignorant
+    /// of packet meaning, and the caller decides what is worth observing.
+    ///
+    /// The filter is unaffected -- what readReceiveBuffer() returns is
+    /// unchanged. The observer runs on the reading thread and must be cheap; it
+    /// is called for every packet in the ring, not just this instrument's.
+    ///
+    /// @param observer Callback, or nullptr to clear
+    void setPacketObserver(std::function<void(const cbPKT_GENERIC&)> observer);
 
     /// @brief Get the number of packets read from the receive buffer
     ///

--- a/src/cbshm/src/central_adapters/v7_0.cpp
+++ b/src/cbshm/src/central_adapters/v7_0.cpp
@@ -1046,6 +1046,14 @@ cbutil::Result<void> Adapter::getProcInfo(::cbPKT_PROCINFO& buf) const {
     return cbutil::Result<void>::ok();
 }
 
+cbutil::Result<void> Adapter::getProcInfoAt(::cbPKT_PROCINFO& buf, uint32_t instrument) const {
+    if (instrument >= std::size(cfg->procinfo)) {
+        return cbutil::Result<void>::error("Instrument index out of range");
+    }
+    fromLegacy(buf, cfg->procinfo[instrument]);
+    return cbutil::Result<void>::ok();
+}
+
 cbutil::Result<void> Adapter::getBankInfo(::cbPKT_BANKINFO& buf, uint32_t bank_num) const {
     uint32_t bank_idx = bank_num - 1;
     if (bank_idx >= std::size(cfg->bankinfo[0])) {

--- a/src/cbshm/src/central_adapters/v7_5.cpp
+++ b/src/cbshm/src/central_adapters/v7_5.cpp
@@ -1041,6 +1041,14 @@ cbutil::Result<void> Adapter::getProcInfo(::cbPKT_PROCINFO& buf) const {
     return cbutil::Result<void>::ok();
 }
 
+cbutil::Result<void> Adapter::getProcInfoAt(::cbPKT_PROCINFO& buf, uint32_t instrument) const {
+    if (instrument >= std::size(cfg->procinfo)) {
+        return cbutil::Result<void>::error("Instrument index out of range");
+    }
+    fromLegacy(buf, cfg->procinfo[instrument]);
+    return cbutil::Result<void>::ok();
+}
+
 cbutil::Result<void> Adapter::getBankInfo(::cbPKT_BANKINFO& buf, uint32_t bank_num) const {
     uint32_t bank_idx = bank_num - 1;
     if (bank_idx >= std::size(cfg->bankinfo[0])) {

--- a/src/cbshm/src/central_adapters/v7_6.cpp
+++ b/src/cbshm/src/central_adapters/v7_6.cpp
@@ -1025,6 +1025,14 @@ cbutil::Result<void> Adapter::getProcInfo(::cbPKT_PROCINFO& buf) const {
     return cbutil::Result<void>::ok();
 }
 
+cbutil::Result<void> Adapter::getProcInfoAt(::cbPKT_PROCINFO& buf, uint32_t instrument) const {
+    if (instrument >= std::size(cfg->procinfo)) {
+        return cbutil::Result<void>::error("Instrument index out of range");
+    }
+    fromLegacy(buf, cfg->procinfo[instrument]);
+    return cbutil::Result<void>::ok();
+}
+
 cbutil::Result<void> Adapter::getBankInfo(::cbPKT_BANKINFO& buf, uint32_t bank_num) const {
     uint32_t bank_idx = bank_num - 1;
     if (bank_idx >= std::size(cfg->bankinfo[0])) {

--- a/src/cbshm/src/central_adapters/v7_7.cpp
+++ b/src/cbshm/src/central_adapters/v7_7.cpp
@@ -1026,6 +1026,14 @@ cbutil::Result<void> Adapter::getProcInfo(::cbPKT_PROCINFO& buf) const {
     return cbutil::Result<void>::ok();
 }
 
+cbutil::Result<void> Adapter::getProcInfoAt(::cbPKT_PROCINFO& buf, uint32_t instrument) const {
+    if (instrument >= std::size(cfg->procinfo)) {
+        return cbutil::Result<void>::error("Instrument index out of range");
+    }
+    fromLegacy(buf, cfg->procinfo[instrument]);
+    return cbutil::Result<void>::ok();
+}
+
 cbutil::Result<void> Adapter::getBankInfo(::cbPKT_BANKINFO& buf, uint32_t bank_num) const {
     uint32_t bank_idx = bank_num - 1;
     if (bank_idx >= std::size(cfg->bankinfo[0])) {

--- a/src/cbshm/src/central_adapters/v7_8.cpp
+++ b/src/cbshm/src/central_adapters/v7_8.cpp
@@ -1026,6 +1026,14 @@ cbutil::Result<void> Adapter::getProcInfo(::cbPKT_PROCINFO& buf) const {
     return cbutil::Result<void>::ok();
 }
 
+cbutil::Result<void> Adapter::getProcInfoAt(::cbPKT_PROCINFO& buf, uint32_t instrument) const {
+    if (instrument >= std::size(cfg->procinfo)) {
+        return cbutil::Result<void>::error("Instrument index out of range");
+    }
+    fromLegacy(buf, cfg->procinfo[instrument]);
+    return cbutil::Result<void>::ok();
+}
+
 cbutil::Result<void> Adapter::getBankInfo(::cbPKT_BANKINFO& buf, uint32_t bank_num) const {
     uint32_t bank_idx = bank_num - 1;
     if (bank_idx >= std::size(cfg->bankinfo[0])) {

--- a/src/cbshm/src/shmem_session.cpp
+++ b/src/cbshm/src/shmem_session.cpp
@@ -870,6 +870,25 @@ uint32_t ShmemSession::getMaxProcs() const {
     }
 }
 
+Result<cbPKT_PROCINFO> ShmemSession::getProcInfoAt(const uint32_t instrument) const {
+    if (!isOpen()) {
+        return Result<cbPKT_PROCINFO>::error("Session not open");
+    }
+    // NATIVE owns exactly one instrument, so only index 0 exists.
+    if (m_impl->layout == ShmemLayout::NATIVE) {
+        if (instrument != 0) {
+            return Result<cbPKT_PROCINFO>::error("Instrument index out of range");
+        }
+        return Result<cbPKT_PROCINFO>::ok(m_impl->nativeCfg()->procinfo);
+    }
+    auto info = Result<cbPKT_PROCINFO>::ok({});
+    auto res = m_impl->adapter->getProcInfoAt(info.value(), instrument);
+    if (res.isError()) {
+        return Result<cbPKT_PROCINFO>::error(res.error());
+    }
+    return info;
+}
+
 cbproto_protocol_version_t ShmemSession::getCompatProtocolVersion() const {
     return m_impl->compat_protocol;
 }

--- a/src/cbshm/src/shmem_session.cpp
+++ b/src/cbshm/src/shmem_session.cpp
@@ -144,6 +144,9 @@ struct ShmemSession::Impl {
     cbproto::InstrumentId inst;
     Mode mode;
     ShmemLayout layout;
+    /// Sees every packet walked, before the instrument filter. See
+    /// setPacketObserver(). Only touched from the reading thread.
+    std::function<void(const cbPKT_GENERIC&)> packet_observer;
     std::unique_ptr<CentralBootstrapAdapterBase> bootstrap_adapter;
     std::unique_ptr<CentralAdapterBase> adapter;
     std::string cfg_name;            // Config buffer name (e.g., "cbCFGbuffer")
@@ -868,6 +871,10 @@ uint32_t ShmemSession::getMaxProcs() const {
         }
         return m_impl->bootstrap_adapter->getMaxProcs();
     }
+}
+
+void ShmemSession::setPacketObserver(std::function<void(const cbPKT_GENERIC&)> observer) {
+    m_impl->packet_observer = std::move(observer);
 }
 
 Result<cbPKT_PROCINFO> ShmemSession::getProcInfoAt(const uint32_t instrument) const {
@@ -2056,6 +2063,14 @@ Result<void> ShmemSession::readReceiveBuffer(cbPKT_GENERIC* packets, size_t max_
         if (m_impl->rec_tailindex > (buflen - m_impl->rec_reserve_len)) {
             m_impl->rec_tailindex = 0;
             m_impl->rec_tailwrap++;
+        }
+
+        // Let an observer see the packet before the filter decides its fate.
+        // The filter below is unchanged; this only exposes what would
+        // otherwise be discarded, so a CENTRAL CLIENT can derive cross-device
+        // clock estimates from instruments it does not itself read.
+        if (m_impl->packet_observer) {
+            m_impl->packet_observer(packets[packets_read]);
         }
 
         // Filter packets so only those from the selected instrument are read.

--- a/tests/integration/test_capi_configuration.cpp
+++ b/tests/integration/test_capi_configuration.cpp
@@ -30,9 +30,13 @@ static std::string makeTempCcfPath() {
 #ifdef _WIN32
     char buf[MAX_PATH];
     GetTempPathA(MAX_PATH, buf);
-    std::string path = std::string(buf) + "cerelink_capi_XXXXXX.ccf";
+    // _mktemp_s requires the six X's to be the LAST six characters. With a
+    // ".ccf" suffix after them it fails with EINVAL and, per its contract,
+    // sets the first character to '\0' -- leaving an unusable path that made
+    // every save look like a CCF writer failure. Substitute first, extend after.
+    std::string path = std::string(buf) + "cerelink_capi_XXXXXX";
     _mktemp_s(&path[0], path.size() + 1);
-    return path;
+    return path + ".ccf";
 #else
     char tmpl[] = "/tmp/cerelink_capi_XXXXXX";
     int fd = mkstemp(tmpl);

--- a/tests/integration/test_sdk_configuration.cpp
+++ b/tests/integration/test_sdk_configuration.cpp
@@ -32,9 +32,13 @@ static std::string makeTempCcfPath() {
 #ifdef _WIN32
     char buf[MAX_PATH];
     GetTempPathA(MAX_PATH, buf);
-    std::string path = std::string(buf) + "cerelink_test_XXXXXX.ccf";
+    // _mktemp_s requires the six X's to be the LAST six characters. With a
+    // ".ccf" suffix after them it fails with EINVAL and, per its contract,
+    // sets the first character to '\0' -- leaving an unusable path that made
+    // every save look like a CCF writer failure. Substitute first, extend after.
+    std::string path = std::string(buf) + "cerelink_test_XXXXXX";
     _mktemp_s(&path[0], path.size() + 1);
-    return path;
+    return path + ".ccf";
 #else
     char tmpl[] = "/tmp/cerelink_test_XXXXXX";
     int fd = mkstemp(tmpl);


### PR DESCRIPTION
Makes every instrument independently addressable through Central: channel access, packet ids, and configuration writes. Two commits — channel windowing, then packet routing.

## 1. A HUB2 session read HUB1's configuration

Both sessions returned byte-identical config, and a HUB2 setter landed on HUB1's channel of the same number. Central's own `Hub{N}-` label prefixes made it unambiguous — a HUB2 session read `'Hub1-chan1'`.

`cbsdk_get_max_chans()` returns the cbproto **wire** constant (`cbMAXPROCS 1` → 284). It is a free function with no session parameter, so it cannot know which device is attached. Central 7.8 lays out **880** channels across four instruments, so the 284 ceiling cut Hub2's block short:

```
Hub1-  ch1..256    'Hub1-chan1' .. 'Hub1-chan256'
Hub2-  ch257..284  'Hub2-chan1' .. 'Hub2-chan28'   <- 28 of 256 visible
```

Hub2's channels 1–28 aliased onto what CereLink believed were **Hub1's analog/Experiment I/O** channels; its remaining 228 were rejected outright.

### Why constants can't fix it

Central packs the *connected* instruments densely and renumbers when that set changes. With two hubs the NSP's `ainp1` starts at 513 (bank 17); with one hub at 257 (bank 9); with none at 1 (bank 1). An earlier attempt using `cbNUM_FE_CHANS` as the I/O base was wrong, and made a `HUB3` session alias onto the NSP's analog inputs — the same bug in a new place.

### Fix

Discover the window at runtime from `procinfo`: `chancount` is authoritative per instrument, each instrument's channels are contiguous, and `base = 1 + Σ chancount(j) for j < instrument`. `chanbase` is device-local (always 1) and deliberately unused.

Sessions are addressed `1..getMaxChans()` in **both** CENTRAL and STANDALONE. Packet chids are translated in `dispatchBatch`; an unresolved or identity window skips the loop, leaving the hot path unaffected. Resolution is lazy because `procinfo` lags session setup unpredictably — a Gemini NSP resolved on three opens out of four even with a one-second wait.

`CentralChannelSpace` and its five implementations were removed in favour of `getProcInfoAt`; the net result is smaller than the code it replaces.

## 2. Nothing but instrument 0 could be configured (#196)

`sync()` timed out for every instrument except 0, and since each `auto_sync` setter runs it first, all config writes failed for those devices.

Outbound CLIENT-mode packets never set `cbpkt_header.instrument`, so all went out as instrument 0; a non-zero-index session's reply is dropped by `readReceiveBuffer`'s instrument filter, hence clean 5.0 s timeouts. The clock probe already stamped the field and carried a comment describing this exact mechanism — it was fixed once there and missed generally. Now stamped in `sendPacket()`, covering every CLIENT send.

That fixed `sync()` but writes still did not land. Only Central's `chaninfo[]` is indexed globally; Central forwards transmit-buffer packets *verbatim* (`InstNetwork` → `Instrument::Send`, a plain UDP send with no per-instrument routing), so the device applies them in its own numbering. Translating the outbound id sent Hub2 a channel 257 it does not have. Validate against the window, send the id unchanged, route by instrument.

## Verification

Two Gemini hubs + a Gemini NSP, Central 7.8 and STANDALONE:

| Session | `max_chans` | ch1 | `sync()` before → after | write lands on itself |
|---|---|---|---|---|
| HUB1 | 256 | `Hub1-chan1` | 5 ok → 5 ok (21 ms) | yes |
| HUB2 | 256 | `Hub2-chan1` | **0 ok / 5 fail → 5 ok** (20 ms) | **yes** |
| NSP | 28 | `ainp1` | **0 ok / 5 fail → 5 ok** (20 ms) | **yes** |
| HUB3 (absent) | 0 | — | — | rejects every id |

NSP bank assignments match the hardware: `ainp1` bank 17, `aout1` bank 18, `dout4` bank 22.

- Soak harness `--native --intense`: **80/80** (HUB1), **81/81** (HUB2). NSP 75/1/2, both failures being harness assumptions since fixed on the base branch.
- `ctest` **482/486**; the four failures are pre-existing, confirmed by stashing this branch and re-running. Three are #197.

Base is `test/hardware-soak-harness` because this depends on the multi-version Central adapters and was validated with that branch's soak harness.

Fixes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)