### PR TITLE
Fix and consolidate config-send pacing

### DIFF
--- a/src/cbdev/src/device_session.cpp
+++ b/src/cbdev/src/device_session.cpp
@@ -745,45 +745,21 @@ Result<void> DeviceSession::sendPackets(const std::vector<cbPKT_GENERIC>& pkts) 
         return Result<void>::error("Device not connected");
     }
 
-    // Send each packet as its own datagram (no coalescing).  Two concerns:
+    // Send each packet as its own datagram (no coalescing).  The receiver's
+    // kernel UDP buffer can be as small as 8 KB (~8 CHANINFO packets), so we
+    // must not send faster than it can drain -- but the pacing lives in
+    // sendPacket(), which every packet below passes through.
     //
-    // 1. Pacing: the receiver's kernel UDP buffer can be as small as 8 KB
-    //    (~8 CHANINFO packets).  We must not send faster than the receiver
-    //    can drain.
-    //
-    // 2. CPU fairness: on shared VMs (CI runners), a pure busy-wait
-    //    between sends starves nPlayServer of CPU, preventing it from
-    //    draining its buffer even when packets arrive slowly.
-    //
-    // Strategy: send a small batch, then yield the CPU so the receiver
-    // process can run.  The batch size (8) matches the worst-case kernel
-    // buffer capacity, so even if the yield takes a while the buffer
-    // won't overflow from the preceding burst.
-    // On Windows, temporarily raise the timer resolution so Sleep(1)
-    // actually sleeps ~1 ms instead of ~15 ms.  The RAII guard restores
-    // the resolution when sendPackets returns.
-#ifdef _WIN32
-    timeBeginPeriod(1);
-    struct TimerGuard { ~TimerGuard() { timeEndPeriod(1); } } timerGuard;
-#endif
-
-    constexpr size_t BATCH = 8;
-    for (size_t i = 0; i < pkts.size(); ++i) {
-        if (auto result = sendPacket(pkts[i]); result.isError()) {
+    // This loop used to add its own throttle: 8 packets back to back, then
+    // Sleep(1), with the system timer resolution raised so that sleep landed
+    // at 1 ms rather than ~15 ms.  That is redundant now, and it was the
+    // coarser of the two -- it deliberately filled the receiver's buffer
+    // before pausing (125 us per packet averaged, in bursts of 8), where
+    // sendPacket() spaces every configuration packet by 200 us and never
+    // bursts.  Removing it leaves pacing strictly gentler on the receiver.
+    for (const auto& pkt : pkts) {
+        if (auto result = sendPacket(pkt); result.isError()) {
             return result;
-        }
-        if ((i % BATCH) == (BATCH - 1)) {
-            // Pace sends so the receiver can drain its kernel UDP buffer.
-            // Sleep(1) yields for one scheduler quantum (~1 ms with the
-            // timer resolution raised above).  On POSIX, sleep_for is
-            // accurate at sub-ms granularity -- note this does NOT hold for
-            // MinGW, where it returns immediately below ~1 ms, which is why
-            // sendPacket's finer per-config gap uses waitUntil() instead.
-#ifdef _WIN32
-            Sleep(1);
-#else
-            std::this_thread::sleep_for(std::chrono::microseconds(50));
-#endif
         }
     }
 

--- a/src/cbdev/src/device_session.cpp
+++ b/src/cbdev/src/device_session.cpp
@@ -66,7 +66,36 @@ namespace {
 #endif
     }
 
-
+    /// @brief Block until @p deadline, accurately below one millisecond
+    ///
+    /// std::this_thread::sleep_for is documented to sleep at least the
+    /// requested duration, but MinGW does not honour that below ~1 ms: it
+    /// returns immediately (measured, g++ 15.2.0: 40 x sleep_for(200us) took
+    /// 0 ms, 40 x sleep_for(500us) took 0 ms).  Configuration pacing asks for
+    /// 200 us, so it silently did nothing in those builds.  Sleeping a whole
+    /// millisecond instead is no answer either — Windows' default timer
+    /// granularity rounds that up to ~15.6 ms (40 x sleep_for(1ms) took
+    /// 616 ms), which would stretch a 256-channel configuration to seconds.
+    ///
+    /// So sleep only whole milliseconds, and yield for the sub-millisecond
+    /// remainder.  Yielding keeps the CPU available to the receiving process:
+    /// a pure busy-wait starves nPlayServer on a shared CI runner, preventing
+    /// it from draining the very buffer this pacing protects.
+    inline void waitUntil(const std::chrono::steady_clock::time_point deadline) {
+        for (;;) {
+            const auto remaining = deadline - std::chrono::steady_clock::now();
+            if (remaining <= std::chrono::steady_clock::duration::zero()) {
+                return;
+            }
+            if (remaining >= std::chrono::milliseconds(2)) {
+                // Leave a millisecond to absorb the timer's coarse granularity,
+                // then close the gap by yielding.
+                std::this_thread::sleep_for(remaining - std::chrono::milliseconds(1));
+            } else {
+                std::this_thread::yield();
+            }
+        }
+    }
 }
 
 namespace cbdev {
@@ -611,10 +640,10 @@ Result<void> DeviceSession::sendPacket(const cbPKT_GENERIC& pkt) {
     if ((pkt.cbpkt_header.chid & cbPKTCHAN_CONFIGURATION) == cbPKTCHAN_CONFIGURATION) {
         constexpr auto kConfigSendMinInterval = std::chrono::microseconds(200);
         if (m_impl->last_config_send.time_since_epoch().count() != 0) {
-            const auto elapsed = std::chrono::steady_clock::now() - m_impl->last_config_send;
-            if (elapsed < kConfigSendMinInterval) {
-                std::this_thread::sleep_for(kConfigSendMinInterval - elapsed);
-            }
+            // waitUntil rather than sleep_for: the gap is sub-millisecond, and
+            // sleep_for does not sleep at all below ~1 ms on MinGW, which left
+            // this throttle inert in those builds.  See waitUntil().
+            waitUntil(m_impl->last_config_send + kConfigSendMinInterval);
         }
         m_impl->last_config_send = std::chrono::steady_clock::now();
     }
@@ -746,8 +775,10 @@ Result<void> DeviceSession::sendPackets(const std::vector<cbPKT_GENERIC>& pkts) 
         if ((i % BATCH) == (BATCH - 1)) {
             // Pace sends so the receiver can drain its kernel UDP buffer.
             // Sleep(1) yields for one scheduler quantum (~1 ms with the
-            // timer resolution raised above).  On other platforms,
-            // sleep_for is already accurate at sub-ms granularity.
+            // timer resolution raised above).  On POSIX, sleep_for is
+            // accurate at sub-ms granularity -- note this does NOT hold for
+            // MinGW, where it returns immediately below ~1 ms, which is why
+            // sendPacket's finer per-config gap uses waitUntil() instead.
 #ifdef _WIN32
             Sleep(1);
 #else

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -1380,10 +1380,15 @@ Result<void> SdkSession::start() {
             while (impl->device_send_thread_running.load()) {
                 bool has_packets = false;
 
-                // Try to dequeue and send all available packets
-#ifdef _WIN32
-                bool timer_raised = false;
-#endif
+                // Try to dequeue and send all available packets.
+                //
+                // No pacing here: DeviceSession::sendPacket enforces the gap
+                // between configuration sends, and every packet below goes
+                // through it. This loop used to sleep 1 ms per 8 packets and
+                // raise the system timer resolution to make that sleep land,
+                // which is redundant now and was coarser than the choke point
+                // -- it burst 8 packets into the device's ~8-packet buffer
+                // before pausing, where the choke point spaces every one.
                 while (true) {
                     cbPKT_GENERIC pkt = {};
 
@@ -1394,31 +1399,15 @@ Result<void> SdkSession::start() {
                     }
 
                     has_packets = true;
-#ifdef _WIN32
-                    if (!timer_raised) { timeBeginPeriod(1); timer_raised = true; }
-#endif
 
-                    // Send packet to device
+                    // Send packet to device (paced by DeviceSession::sendPacket)
                     auto send_result = impl->device_session->sendPacket(pkt);
                     if (send_result.isError()) {
                         impl->stats.send_errors.fetch_add(1, std::memory_order_relaxed);
                     } else {
                         impl->stats.packets_sent_to_device.fetch_add(1, std::memory_order_relaxed);
                     }
-
-                    // Pace sends to avoid overflowing the device's kernel
-                    // UDP receive buffer (~8 KB on Windows = ~8 packets).
-                    if ((impl->stats.packets_sent_to_device.load(std::memory_order_relaxed) % 8) == 0) {
-#ifdef _WIN32
-                        Sleep(1);
-#else
-                        std::this_thread::sleep_for(std::chrono::microseconds(50));
-#endif
-                    }
                 }
-#ifdef _WIN32
-                if (timer_raised) timeEndPeriod(1);
-#endif
 
                 if (!has_packets) {
                     // No packets - wait briefly before checking again

--- a/tests/unit/test_device_session.cpp
+++ b/tests/unit/test_device_session.cpp
@@ -344,8 +344,14 @@ TEST_F(DeviceSessionTest, Error_SendPacketsEmpty) {
 // overrun a device's small UDP receive buffer (which drops packets, including a
 // following runlevel sync barrier). sendPacket() enforces a minimum gap between
 // consecutive configuration-channel sends; streaming/data packets are exempt.
-// std::this_thread::sleep_for only ever sleeps AT LEAST the requested time, so
-// the lower-bound timing assertion below cannot be flaky.
+//
+// The assertion is a lower bound on elapsed time, so it cannot fail from the
+// machine being slow. It CAN fail if the gap is not enforced at all, which is
+// what it is for: sendPacket originally waited with std::this_thread::sleep_for,
+// which MinGW does not honour below ~1 ms -- it returns immediately, leaving the
+// throttle inert in those builds while CI's toolchains passed. Do not "fix" a
+// failure here by relaxing the bound without first checking that the wait
+// primitive actually waits on the failing platform.
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 TEST_F(DeviceSessionTest, ConfigSends_ArePaced_DataSends_AreNot) {


### PR DESCRIPTION
Fixes the one red test on master, then removes the redundancy that let it hide. Two commits, revertible independently.

## 1. The gap never waited on MinGW

`DeviceSessionTest.ConfigSends_ArePaced_DataSends_AreNot` was reporting a real defect, not flakiness — 40 configuration packets went out in **0 ms**. It is a loopback unit test, so no device or firmware is involved.

`std::this_thread::sleep_for` is specified to sleep at least the requested duration. MinGW does not honour that below ~1 ms (g++ 15.2.0):

```
40 x sleep_for( 200us) =    0 ms   <- returns immediately
40 x sleep_for( 500us) =    0 ms   <- returns immediately
40 x sleep_for(1000us) =  616 ms   <- sleeps, rounds up to ~15.6 ms
```

The interval is 200 µs, so the throttle was inert in every build from this toolchain — the one local DLLs come from. CI passed because its Windows toolchain and the POSIX runners honour sub-millisecond sleeps.

Raising the interval to 1 ms is no answer either: that 616 ms row is Windows rounding up to its default timer granularity, which would stretch a 256-channel configuration to seconds.

**Fix:** wait on a deadline — sleep whole milliseconds, yield the sub-millisecond remainder. Yielding rather than busy-waiting keeps the CPU available to the receiver, which `sendPackets` documented as necessary to avoid starving nPlayServer on shared CI runners.

## 2. Three pacing layers, now one

Pacing was implemented three times, all STANDALONE-only:

| location | mechanism | effective on MinGW? |
|---|---|---|
| `DeviceSession::sendPacket` | 200 µs per config packet | **no** — this PR fixes it |
| `DeviceSession::sendPackets` | 8 packets + `Sleep(1)` | yes — **removed** |
| `SdkSession` send thread | 8 packets + `Sleep(1)` | yes — **removed** |

The outer two are what masked the defect, and they were the *coarser* option: 8 packets back to back to fill the receiver's ~8-packet buffer, then a pause — 125 µs per packet averaged, in bursts. The choke point spaces every configuration packet by 200 µs and never bursts, so removing them leaves pacing **gentler on the receiver, not weaker**.

Every STANDALONE send funnels through `sendPacket`, so nothing loses its throttle. One narrowing is deliberate: the outer layers throttled all packet types, while the choke point throttles only configuration packets — the documented intent, which the test asserts.

Both removed layers also raised the Windows timer resolution via `timeBeginPeriod(1)` solely to make their `Sleep(1)` land. That is process-wide with power-management side effects and is no longer needed.

## Verification

- **394/394** non-hardware tests — the first fully green run for this suite.
- The pacing test passes 5/5 consecutive runs.
- On a Gemini hub in STANDALONE, bulk paths are faster with no loss of correctness:

| operation | before | after |
|---|---|---|
| `set_sample_group`, 256 channels | 96 ms | **51 ms**, lands 256/256 both directions |
| `load_ccf_sync` | — | **282 ms**, configuration applied |

## Caveat

This bench runs **7.8 firmware**, which may not need pacing at all. A green result here does not prove the gentler profile is sufficient for the older devices that motivated the pacing — that wants a legacy analog NSP, which nobody on the team has. The two commits are separable so the consolidation can be reverted without losing the fix.

The gap is kept for all configurations including 7.8; making it conditional on firmware is now a one-place change rather than three.

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)