### PR TITLE
Fix CLIENT-mode abort on macOS and guard the native shmem layout

### DIFF
--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -1022,6 +1022,14 @@ Result<SdkSession> SdkSession::create(const SdkConfig& config) {
             cbshm::Mode::CLIENT, cbshm::ShmemLayout::NATIVE, device_tag,
             cbproto::InstrumentId::fromIndex(0));
 
+        // Not the same as "nothing to attach to": the owner is probably alive,
+        // and the STANDALONE fallback below would unlink and recreate these
+        // very segments, taking the device away from it.
+        if (shmem_result.isError() && cbshm::isIncompatibleLayoutError(shmem_result.error())) {
+            return Result<SdkSession>::error("Failed to attach to shared memory: " +
+                                             shmem_result.error());
+        }
+
         // Liveness check: reject stale segments from a dead STANDALONE process.
         // The ShmemSession destructor (triggered by reassignment) unmaps the segments;
         // the subsequent STANDALONE creation path will shm_unlink + recreate them.

--- a/src/cbsdk/src/sdk_session.cpp
+++ b/src/cbsdk/src/sdk_session.cpp
@@ -316,10 +316,14 @@ struct SdkSession::Impl {
         uint32_t global_start;  ///< 1-based, inclusive
     };
     // Mutable so an unresolved window can still be resolved from const
-    // accessors -- see ensureWindowResolved().
+    // accessors -- see ensureWindowResolved().  That rebuild can come from any
+    // thread while the receive thread iterates chan_segs, so the three fields
+    // below move together under window_mutex.  local_max_chans is also atomic:
+    // the per-packet dispatch path reads it without taking the mutex.
+    mutable std::mutex window_mutex;                ///< guards the three fields below
     mutable std::vector<ChanSeg> chan_segs;         ///< the mapped ranges
     mutable bool window_resolved = false;           ///< false => identity map (unknown)
-    mutable uint32_t local_max_chans = cbMAXCHANS;  ///< channels this device has
+    mutable std::atomic<uint32_t> local_max_chans{cbMAXCHANS};  ///< channels this device has
     uint32_t central_instrument = 0;                ///< instrument this session speaks for
 
     /// @brief Resolve the window on first use if it could not be resolved yet
@@ -329,16 +333,23 @@ struct SdkSession::Impl {
     /// unresolved window silently reports the whole wire space. Retrying at the
     /// point of use removes the timing sensitivity entirely; once resolved this
     /// is a single bool test.
-    void ensureWindowResolved() const {
+    /// @pre window_mutex held
+    void ensureWindowResolvedLocked() const {
         if (!window_resolved) {
-            const_cast<Impl*>(this)->buildChannelWindow(central_instrument);
+            const_cast<Impl*>(this)->buildChannelWindowLocked(central_instrument);
         }
+    }
+
+    void ensureWindowResolved() const {
+        std::lock_guard<std::mutex> lk(window_mutex);
+        ensureWindowResolvedLocked();
     }
 
     /// @brief Map a local (per-device) channel id onto Central's global id
     /// @return the global id, or 0 if this device has no such channel
-    uint32_t toGlobalChan(const uint32_t local) const {
-        if (local < 1 || local > local_max_chans) return 0;
+    /// @pre window_mutex held
+    uint32_t toGlobalChanLocked(const uint32_t local) const {
+        if (local < 1 || local > local_max_chans.load(std::memory_order_relaxed)) return 0;
         // An unresolved window is the identity; a resolved but empty one means
         // the device is not present and nothing is addressable.
         if (!window_resolved) return local;
@@ -349,13 +360,22 @@ struct SdkSession::Impl {
         return 0;
     }
 
+    /// @brief Locking wrapper for the one-shot callers outside the receive path
+    uint32_t toGlobalChan(const uint32_t local) const {
+        std::lock_guard<std::mutex> lk(window_mutex);
+        ensureWindowResolvedLocked();
+        return toGlobalChanLocked(local);
+    }
+
     /// @brief Inverse of toGlobalChan()
     ///
     /// Returns 0 when the global id belongs to a different instrument, which is
     /// how packets for other devices are recognised and ignored.
-    uint32_t toLocalChan(const uint32_t global) const {
+    /// @pre window_mutex held
+    uint32_t toLocalChanLocked(const uint32_t global) const {
         if (global < 1) return 0;
-        if (!window_resolved) return global <= local_max_chans ? global : 0;
+        if (!window_resolved)
+            return global <= local_max_chans.load(std::memory_order_relaxed) ? global : 0;
         for (const auto& s : chan_segs) {
             if (global >= s.global_start && global < s.global_start + s.count)
                 return s.local_start + (global - s.global_start);
@@ -375,7 +395,8 @@ struct SdkSession::Impl {
     /// range: local 1..chancount maps to global base..base+chancount-1, where
     /// base is 1 plus the running sum of the preceding instruments' chancount.
     /// A device reporting chancount 0 is not present.
-    void buildChannelWindow(const uint32_t instrument) {
+    /// @pre window_mutex held
+    void buildChannelWindowLocked(const uint32_t instrument) {
         chan_segs.clear();
         window_resolved = false;
         local_max_chans = cbMAXCHANS;
@@ -409,8 +430,15 @@ struct SdkSession::Impl {
             local_max_chans = 0;
             return;
         }
-        chan_segs.push_back({1, count, base});
-        local_max_chans = count;
+        // chancount comes off the wire and can exceed the compile-time
+        // cbMAXCHANS that sizes every local-channel buffer, notably
+        // channel_type_cache; an unclamped count writes past them and over the
+        // Impl members that follow, several of which are std::mutex.  base is
+        // deliberately not clamped -- it indexes Central's global space, which
+        // must stay exact.
+        const uint32_t local_count = std::min<uint32_t>(count, cbMAXCHANS);
+        chan_segs.push_back({1, local_count, base});
+        local_max_chans = local_count;
     }
 
     /// @brief Resolve the channel window, retrying briefly if procinfo lags
@@ -424,8 +452,13 @@ struct SdkSession::Impl {
     /// lifetime.
     void resolveChannelWindow(const int attempts = 20) {
         for (int i = 0; i < attempts; ++i) {
-            buildChannelWindow(central_instrument);
-            if (window_resolved) return;
+            {
+                // Released around the sleep so a concurrent packet-translation
+                // batch is not blocked for the whole retry budget.
+                std::lock_guard<std::mutex> lk(window_mutex);
+                buildChannelWindowLocked(central_instrument);
+                if (window_resolved) return;
+            }
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
         }
     }
@@ -441,7 +474,8 @@ struct SdkSession::Impl {
 
     void rebuildChannelTypeCache() {
         channel_type_cache.fill(ChannelType::ANY);
-        for (uint32_t ch = 0; ch < local_max_chans; ++ch) {
+        const uint32_t n = local_max_chans.load(std::memory_order_relaxed);
+        for (uint32_t ch = 0; ch < n; ++ch) {
             auto ci = getChanInfo(ch + 1);
             channel_type_cache[ch] = ci.isOk() ? classifyChannelByCaps(ci.value()) : ChannelType::ANY;
         }
@@ -454,7 +488,7 @@ struct SdkSession::Impl {
         // store, so the answer cannot depend on which one replies.  A hub has
         // no I/O channels, but the wire layout still reserves slots at 257..,
         // and the device happily returns the empty chaninfo sitting there.
-        ensureWindowResolved();
+        // toGlobalChan() resolves the window first if it still needs it.
         const uint32_t global = toGlobalChan(chan_id);
         if (!global) {
             return Result<cbPKT_CHANINFO>::error("Channel not present on this device");
@@ -742,18 +776,25 @@ struct SdkSession::Impl {
         //
         // An identity map — NATIVE, STANDALONE, or a single-instrument
         // Central — skips the loop entirely, so the hot path is unaffected.
-        if (!chan_segs.empty()) {
-            for (size_t i = 0; i < count; i++) {
-                const uint16_t chid = packets[i].cbpkt_header.chid;
-                // chid 0 is a sample group and the high bit marks configuration
-                // packets; neither is a channel id.
-                if (chid == 0 || (chid & cbPKTCHAN_CONFIGURATION)) continue;
-                const uint32_t local = toLocalChan(chid);
-                // 0 means the channel belongs to another instrument, which the
-                // receive-buffer instrument filter should already have dropped.
-                // Leave it alone rather than rewriting it to 0, which would
-                // masquerade as a sample group.
-                if (local) packets[i].cbpkt_header.chid = static_cast<uint16_t>(local);
+        //
+        // The lock is held once for the batch, not per packet: it only has to
+        // stop a concurrent ensureWindowResolved() refilling chan_segs under
+        // the iteration.
+        {
+            std::lock_guard<std::mutex> lk(window_mutex);
+            if (!chan_segs.empty()) {
+                for (size_t i = 0; i < count; i++) {
+                    const uint16_t chid = packets[i].cbpkt_header.chid;
+                    // chid 0 is a sample group and the high bit marks configuration
+                    // packets; neither is a channel id.
+                    if (chid == 0 || (chid & cbPKTCHAN_CONFIGURATION)) continue;
+                    const uint32_t local = toLocalChanLocked(chid);
+                    // 0 means the channel belongs to another instrument, which the
+                    // receive-buffer instrument filter should already have dropped.
+                    // Leave it alone rather than rewriting it to 0, which would
+                    // masquerade as a sample group.
+                    if (local) packets[i].cbpkt_header.chid = static_cast<uint16_t>(local);
+                }
             }
         }
 
@@ -1023,7 +1064,8 @@ Result<SdkSession> SdkSession::create(const SdkConfig& config) {
             session.m_impl->shmem_session->getLayout() == cbshm::ShmemLayout::CENTRAL;
         session.m_impl->central_instrument =
             central_layout && inst_idx >= 0 ? static_cast<uint32_t>(inst_idx) : 0u;
-        session.m_impl->buildChannelWindow(session.m_impl->central_instrument);
+        std::lock_guard<std::mutex> lk(session.m_impl->window_mutex);
+        session.m_impl->buildChannelWindowLocked(session.m_impl->central_instrument);
     }
 
     // Create device session only in STANDALONE mode
@@ -1669,7 +1711,13 @@ Result<void> SdkSession::start() {
 }
 
 void SdkSession::stop() {
-    if (!m_impl || !m_impl->is_running.load()) {
+    // Gate on the Impl, never on is_running: start() sets that flag last, so it
+    // is false for the whole window in which the worker threads are already
+    // live.  Returning early there skips every join below and the destructor
+    // then frees the Impl under a running thread -- which aborts with "mutex
+    // lock failed: Invalid argument" once that thread locks a destroyed mutex.
+    // Each join is guarded by its own thread's flag, so this is idempotent.
+    if (!m_impl) {
         return;
     }
 

--- a/src/cbshm/include/cbshm/native_types.h
+++ b/src/cbshm/include/cbshm/native_types.h
@@ -64,8 +64,38 @@ constexpr uint32_t NATIVE_cbPKT_SPKCACHELINECNT = NATIVE_NUM_ANALOG_CHANS;      
 /// It uses scalar fields instead of arrays for per-instrument data, and uses
 /// cbMAXCHANS (284) instead of cbCONFIG_MAXCHANS (848) for channel arrays.
 ///
+/// @brief Layout revision of NativeConfigBuffer
+///
+/// Bump whenever a field is added, removed, or reordered.  Builds that disagree
+/// cannot share a segment: every field past the change is read at the wrong
+/// offset and the reader has no way to notice.  9.13 dropped
+/// optiontable/colortable and added segment_uid, shifting clock_offset_ns,
+/// owner_pid and segment_uid by 512 bytes — so a 9.13 CLIENT on a 9.12 segment
+/// takes its clock sync, liveness and supersession state from arbitrary bytes.
+constexpr uint32_t NATIVE_CONFIG_LAYOUT_VERSION = 2;
+
+/// @brief Pack the layout revision and the protocol version into cfg->version
+///
+/// High 8 bits are the layout revision, low 24 the cbproto version this field
+/// has always carried.  Builds before 9.13 wrote only the latter, so they read
+/// back as layout 0 -- which is how a pre-9.13 segment is recognised without a
+/// field that did not exist then.
+constexpr uint32_t makeNativeConfigVersion(const uint32_t protocol_version) {
+    return (NATIVE_CONFIG_LAYOUT_VERSION << 24) | (protocol_version & 0x00FFFFFFu);
+}
+
+/// @brief Recover the layout revision from cfg->version
+constexpr uint32_t nativeConfigLayoutVersion(const uint32_t version) {
+    return version >> 24;
+}
+
+/// @brief Recover the cbproto version from cfg->version
+constexpr uint32_t nativeConfigProtocolVersion(const uint32_t version) {
+    return version & 0x00FFFFFFu;
+}
+
 typedef struct {
-    uint32_t version;           ///< Buffer structure version
+    uint32_t version;           ///< Layout revision (high 8 bits) + cbproto version (low 24)
     uint32_t sysflags;          ///< System-wide flags
 
     // Single instrument status

--- a/src/cbshm/include/cbshm/shmem_session.h
+++ b/src/cbshm/include/cbshm/shmem_session.h
@@ -51,6 +51,18 @@ enum class ShmemLayout {
     NATIVE           ///< Native single-instrument layout (NativeConfigBuffer)
 };
 
+/// @brief Prefix on the create() error for a segment written by an incompatible build
+///
+/// Callers must tell this apart from "no segment there", whose usual answer is
+/// to become STANDALONE -- which unlinks and recreates the segments, tearing
+/// them out from under an owner that is merely a different version.
+constexpr const char* INCOMPATIBLE_LAYOUT_ERROR = "Incompatible shared memory layout: ";
+
+/// @brief Whether a create() error reports an incompatible segment layout
+inline bool isIncompatibleLayoutError(const std::string& error) {
+    return error.rfind(INCOMPATIBLE_LAYOUT_ERROR, 0) == 0;
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 /// @brief Shared memory session for Cerebus configuration and data buffers
 ///

--- a/src/cbshm/src/shmem_session.cpp
+++ b/src/cbshm/src/shmem_session.cpp
@@ -644,7 +644,7 @@ struct ShmemSession::Impl {
         if (mode == Mode::STANDALONE && layout == ShmemLayout::NATIVE) {
             auto* cfg = nativeCfg();
             std::memset(cfg, 0, cfg_buffer_size);
-            cfg->version = cbVERSION_MAJOR * 100 + cbVERSION_MINOR;
+            cfg->version = makeNativeConfigVersion(cbVERSION_MAJOR * 100 + cbVERSION_MINOR);
             cfg->instrument_status = static_cast<uint32_t>(InstrumentStatus::INACTIVE);
             // Ownership + per-creation identity.  owner_pid detects a crashed owner;
             // segment_uid detects a live owner that recreated this segment under the
@@ -717,6 +717,31 @@ struct ShmemSession::Impl {
         }
 
         is_open = true;
+
+        // Refuse a segment whose NativeConfigBuffer layout is not ours.  Nothing
+        // downstream can detect the mismatch -- every field still reads as
+        // *something* -- so it would surface as quietly wrong clock sync and
+        // liveness state rather than as a failed attach.
+        if (mode == Mode::CLIENT && layout == ShmemLayout::NATIVE && cfg_buffer_raw) {
+            const uint32_t their_version = nativeCfg()->version;
+            const uint32_t their_layout = nativeConfigLayoutVersion(their_version);
+            if (their_layout != NATIVE_CONFIG_LAYOUT_VERSION) {
+                const uint32_t their_proto = nativeConfigProtocolVersion(their_version);
+                std::string owner_desc =
+                    their_proto ? (" (protocol " + std::to_string(their_proto / 100) + "." +
+                                   std::to_string(their_proto % 100) + ")")
+                                : std::string();
+                close();
+                return Result<void>::error(
+                    std::string(INCOMPATIBLE_LAYOUT_ERROR) +
+                    "the owner wrote config layout " + std::to_string(their_layout) +
+                    owner_desc + ", but this build requires layout " +
+                    std::to_string(NATIVE_CONFIG_LAYOUT_VERSION) +
+                    ". Layout 0 means the owner predates CereLink 9.13."
+                    " Update every process sharing this device to the same"
+                    " CereLink version.");
+            }
+        }
 
         // Snapshot the segment identity we attached to (STANDALONE has just
         // written it in initBuffers(); CLIENT reads what the owner wrote).  Used

--- a/tests/unit/test_sdk_session.cpp
+++ b/tests/unit/test_sdk_session.cpp
@@ -82,6 +82,41 @@ TEST_F(SdkSessionTest, Create_MoveConstruction) {
     EXPECT_TRUE(session2.isRunning());  // Session is started
 }
 
+/// procinfo.chancount comes off the wire and can exceed the compile-time
+/// cbMAXCHANS.  Taken verbatim it overran channel_type_cache — a
+/// std::array<ChannelType, cbMAXCHANS> in the session's Impl — and wrote over
+/// the members after it, several of which are std::mutex.  A smashed mutex
+/// makes pthread_mutex_lock return EINVAL, which libc++ raises as an uncaught
+/// "mutex lock failed: Invalid argument" on the next SDK thread to lock it.
+TEST_F(SdkSessionTest, ChannelWindow_ClampsOversizedChancount) {
+    // Own the native segments first so the session under test attaches to them
+    // as a CLIENT and reads the procinfo we plant here.
+    auto owner = cbshm::ShmemSession::create(
+        cbshm::Mode::STANDALONE, cbshm::ShmemLayout::NATIVE, "hub3",
+        cbproto::InstrumentId::fromIndex(0));
+    ASSERT_TRUE(owner.isOk()) << "Error: " << owner.error();
+
+    cbPKT_PROCINFO info;
+    std::memset(&info, 0, sizeof(info));
+    info.proc = 1;
+    info.chancount = cbMAXCHANS + 228;  // a device with more channels than we were built for
+    ASSERT_TRUE(owner.value().setProcInfo(info).isOk());
+    ASSERT_TRUE(owner.value().setInstrumentActive(true).isOk());
+
+    SdkConfig config;
+    config.device_type = DeviceType::HUB3;
+    config.autorun = false;
+
+    auto result = SdkSession::create(config);
+    ASSERT_TRUE(result.isOk()) << "Error: " << result.error();
+
+    auto& session = result.value();
+    EXPECT_FALSE(session.isStandalone()) << "expected to attach as CLIENT";
+    EXPECT_LE(session.getMaxChans(), static_cast<uint32_t>(cbMAXCHANS));
+
+    session.stop();
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Session Lifecycle Tests
 ///////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
A pycbsdk 9.13.0 pipeline aborted on macOS almost immediately; reverting to 9.12.1 cleared it. The crash report puts the fault on the CLIENT shared-memory receive thread:

```
SdkSession::start()::$_5                     <- shmem_receive_thread
cbdev::ClockSync::addDataPacketSample(...)
std::__1::mutex::lock()
std::__1::__throw_system_error(int, char const*)
abort
```

`pthread_mutex_lock` returns `EINVAL` when the mutex has been destroyed or overwritten. glibc does not validate the signature, so the same defect is silent on Linux — which is why Windows-only testing before the release missed it.

## Commit 1 — the abort

`SdkSession::stop()` gated every thread join on `is_running`. `start()` sets that flag **last**, after the receive thread is already live (line 379 vs. 561), and `stop()` clears it first. Teardown anywhere in that window — including the `create()` error path that destroys a half-started session — skipped the joins, and `~Impl` then freed `client_clock_sync` under the running thread. Gating on the `Impl` instead is correct and idempotent, since each join is already guarded by its own thread's flag.

Two further defects, both new in 9.13.0, reach the same mutex:

- **Unclamped channel window.** `procinfo.chancount` comes off the wire and can exceed the compile-time `cbMAXCHANS` that sizes `channel_type_cache` — a `std::array` declared ahead of `client_clock_sync` in the same `Impl`. Reproduced deterministically by the new test under libc++ hardening: `array<ChannelType, 284ul>::operator[](__n=284)` from `rebuildChannelTypeCache`.
- **Unsynchronised window rebuild.** `ensureWindowResolved()` refills `chan_segs` from whichever thread calls a channel accessor, while the receive thread iterates it per packet. pycbsdk 9.13.0 made this far likelier by calling `max_chans()` inside `get_channel_field()`. Now under a mutex taken once per batch, with `local_max_chans` atomic so per-packet dispatch stays lock-free.

## Commit 2 — the trigger

The reporting setup has a separate service still on CereLink 9.12 owning the shared memory, with the 9.13 pipeline attaching as a CLIENT. 9.13 changed `NativeConfigBuffer` (dropped `optiontable`/`colortable`, added `segment_uid`) and nothing checked: `cfg->version` was written by the owner and never read. Measured by compiling both headers:

| `offsetof` | 9.12.1 | 9.13.0 |
|---|---|---|
| `procinfo` | 52 | 52 |
| `fileinfo` | 1,035,796 | 1,035,796 |
| `clock_offset_ns` | 1,037,108 | **1,036,596** |
| `owner_pid` | 1,037,132 | **1,036,620** |

Everything through `fileinfo` keeps its offset, so `procinfo`/`chaninfo` survive; everything after shifts 512 bytes, so clock sync, the liveness check and the new supersession check all run on arbitrary bytes. Nothing fails outright — that is the problem.

Adds `NATIVE_CONFIG_LAYOUT_VERSION` in the high 8 bits of the version field the owner already writes (pre-9.13 builds read back as layout 0), and tags the resulting error so `create()` does **not** fall through to its STANDALONE fallback — that path `shm_unlink`s and recreates the segments, which would take the device away from a live owner that is merely a different revision.

## Verification

- 408/408 C++ tests pass. Run ctest **serially**; `-j4` trips pre-existing shmem-name collisions between parallel tests, unrelated to this branch.
- 161 passed / 3 skipped in the pycbsdk suite against a dylib built from this branch.
- Mixed-version repro (pycbsdk 9.12.1 STANDALONE owner on nPlay + 9.13.0 CLIENT): previously attached and streamed on garbage metadata; now refuses with `Incompatible shared memory layout: the owner wrote config layout 0 (protocol 4.2), but this build requires layout 2. ...`, and the owner keeps streaming through the refusal.
- Same-version owner/client pair still streams normally.

## Notes for review

- The `stop()` fix is timing-dependent and has no deterministic regression test; the suites are the only cover. Worth confirming against the real service before cutting 9.13.1.
- ASan is unusable on macOS 26 — its runtime deadlocks in its own initialisation. `-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG` was used instead and caught the array overrun directly.
- Consumers pinning `pycbsdk>=9.13.0` will now hard-fail against a 9.12 owner rather than running on bad data. That is the intended behaviour, but it means the owning service has to be updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)